### PR TITLE
Fix: HTTP Bearer token authentication not being recognized in streamable-http transport

### DIFF
--- a/meta_ads_mcp/core/api.py
+++ b/meta_ads_mcp/core/api.py
@@ -6,7 +6,8 @@ import httpx
 import asyncio
 import functools
 import os
-from .auth import needs_authentication, get_current_access_token, auth_manager, start_callback_server, shutdown_callback_server
+from . import auth
+from .auth import needs_authentication, auth_manager, start_callback_server, shutdown_callback_server
 from .utils import logger
 
 # Constants
@@ -203,7 +204,7 @@ def meta_api_tool(func):
             # If access_token is not in kwargs or not kwargs['access_token'], try to get it from auth_manager
             if 'access_token' not in kwargs or not kwargs['access_token']:
                 try:
-                    access_token = await get_current_access_token()
+                    access_token = await auth.get_current_access_token()
                     if access_token:
                         kwargs['access_token'] = access_token
                         logger.debug("Using access token from auth_manager")

--- a/meta_ads_mcp/core/authentication.py
+++ b/meta_ads_mcp/core/authentication.py
@@ -29,7 +29,8 @@ from typing import Optional
 import asyncio
 import os
 from .api import meta_api_tool
-from .auth import start_callback_server, shutdown_callback_server, auth_manager, get_current_access_token
+from . import auth
+from .auth import start_callback_server, shutdown_callback_server, auth_manager
 from .server import mcp_server
 from .utils import logger, META_APP_SECRET
 from .pipeboard_auth import pipeboard_auth_manager

--- a/meta_ads_mcp/core/duplication.py
+++ b/meta_ads_mcp/core/duplication.py
@@ -6,7 +6,7 @@ import httpx
 from typing import Optional, Dict, Any, List, Union
 from .server import mcp_server
 from .api import meta_api_tool
-from .auth import get_current_access_token
+from . import auth
 from .http_auth_integration import FastMCPAuthIntegration
 
 
@@ -204,7 +204,7 @@ async def _forward_duplication_request(resource_type: str, resource_id: str, acc
         
         # Use provided access_token parameter if no Facebook token found in context
         if not facebook_token:
-            facebook_token = access_token if access_token else await get_current_access_token()
+            facebook_token = access_token if access_token else await auth.get_current_access_token()
         
         # Validate we have both required tokens
         if not pipeboard_token:


### PR DESCRIPTION
## Problem

When making HTTP requests with a Bearer token in the `Authorization` header, the authentication was being ignored. The system would fall back to generating a Facebook OAuth URL with `YOUR_META_APP_ID`, causing authentication failures.

## Root Cause

The HTTP authentication patching system was replacing `get_current_access_token()` at runtime, but modules using direct imports were calling their local copy instead of the patched version:

```python
from .auth import get_current_access_token  # Local reference, not patched
```

This meant the Bearer token from HTTP context was never retrieved.

## Solution

Changed to module-level imports so the patched function is properly called:

```python
from . import auth
access_token = await auth.get_current_access_token()  # Now calls patched version
```

## Files Changed

- `meta_ads_mcp/core/api.py`
- `meta_ads_mcp/core/authentication.py`
- `meta_ads_mcp/core/duplication.py`

## Testing

Tested with Bearer token in streamable-http transport - authentication now works correctly. All existing authentication methods (stdio, Pipeboard, environment variables) remain unchanged.