### PR TITLE
feat: add appsecret_proof to all Graph API requests

### DIFF
--- a/meta_ads_mcp/core/api.py
+++ b/meta_ads_mcp/core/api.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Optional, Callable
 import json
+import hmac
+import hashlib
 import httpx
 import asyncio
 import functools
@@ -30,6 +32,7 @@ USER_AGENT = "meta-ads-mcp/1.0"
 logger.info("Core API module initialized")
 logger.info(f"Graph API Version: {META_GRAPH_API_VERSION}")
 logger.info(f"META_APP_ID env var present: {'Yes' if os.environ.get('META_APP_ID') else 'No'}")
+logger.info(f"META_APP_SECRET env var present (appsecret_proof will be {'enabled' if os.environ.get('META_APP_SECRET') else 'disabled'})")
 
 class GraphAPIError(Exception):
     """Exception raised for errors from the Graph API."""
@@ -124,9 +127,21 @@ async def make_api_request(
     
     request_params = params or {}
     request_params["access_token"] = access_token
-    
+
+    # Add appsecret_proof when META_APP_SECRET is configured.
+    # Required for system user tokens and recommended by Meta for all
+    # server-to-server API calls to verify token authenticity.
+    # See: https://developers.facebook.com/docs/graph-api/securing-requests/
+    app_secret = os.environ.get("META_APP_SECRET", "")
+    if app_secret and access_token:
+        request_params["appsecret_proof"] = hmac.new(
+            app_secret.encode("utf-8"),
+            access_token.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
     # Logging the request (masking token for security)
-    masked_params = {k: "***TOKEN***" if k == "access_token" else v for k, v in request_params.items()}
+    masked_params = {k: "***MASKED***" if k in ("access_token", "appsecret_proof") else v for k, v in request_params.items()}
     logger.debug(f"API Request: {method} {url}")
     logger.debug(f"Request params: {masked_params}")
     


### PR DESCRIPTION
## Summary

When `META_APP_SECRET` is configured as an environment variable, this PR computes an HMAC-SHA256 signature of the access token and includes it as the `appsecret_proof` parameter on every Graph API request.

This is **required** for system user tokens and **recommended by Meta** for all server-to-server API calls to prevent token theft via man-in-the-middle attacks.

### What changed

- **`meta_ads_mcp/core/api.py`** — Added `appsecret_proof` generation in `make_api_request()`, the central function all tools use. When `META_APP_SECRET` is present, the proof is computed and appended automatically. When it's absent, behavior is unchanged.
- Startup log now indicates whether `appsecret_proof` will be enabled based on env config.
- The `appsecret_proof` value is masked in debug logs alongside `access_token`.

### Why

System user tokens (the recommended approach for server-to-server integrations) require `appsecret_proof` on every API call. Without it, all requests return `OAuthException` code 190. This blocks anyone using the MCP server with a system user token instead of a short-lived user token.

### Reference

- [Meta: Securing Graph API Requests](https://developers.facebook.com/docs/graph-api/securing-requests/)

### Testing

Tested against a live Meta Business account with a system user token. Confirmed:
- `get_ad_accounts` returns account data
- `get_campaigns` returns campaign data with full metadata
- No change in behavior when `META_APP_SECRET` is not set (backward compatible)