### PR TITLE
Add Instagram Insights and Custom Audiences tools (8 new MCP tools)

### DIFF
--- a/meta_ads_mcp/core/__init__.py
+++ b/meta_ads_mcp/core/__init__.py
@@ -12,6 +12,8 @@ from .auth import login
 from . import ads_library  # Import module to register conditional tools
 from .budget_schedules import create_budget_schedule
 from .targeting import search_interests, get_interest_suggestions, estimate_audience_size, search_behaviors, search_demographics, search_geo_locations
+from .audiences import get_custom_audiences, create_custom_audience, create_lookalike_audience
+from .instagram_insights import list_media, get_media_insights, get_ig_account_insights, get_story_insights, publish_media
 from . import reports  # Import module to register conditional tools
 from . import duplication  # Import module to register conditional duplication tools
 from .openai_deep_research import search, fetch  # OpenAI MCP Deep Research tools
@@ -44,6 +46,14 @@ __all__ = [
     'search_behaviors',
     'search_demographics',
     'search_geo_locations',
+    'get_custom_audiences',
+    'create_custom_audience',
+    'create_lookalike_audience',
+    'list_media',
+    'get_media_insights',
+    'get_ig_account_insights',
+    'get_story_insights',
+    'publish_media',
     'search',  # OpenAI MCP Deep Research search tool
     'fetch',   # OpenAI MCP Deep Research fetch tool
 ] 

--- a/meta_ads_mcp/core/audiences.py
+++ b/meta_ads_mcp/core/audiences.py
@@ -1,0 +1,150 @@
+"""Custom audience tools for Meta Ads API."""
+
+import json
+from typing import Optional, Dict, Any
+from .api import meta_api_tool, make_api_request
+from .server import mcp_server
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def get_custom_audiences(account_id: str, access_token: Optional[str] = None) -> str:
+    """
+    Get custom audiences for a Meta Ads account.
+
+    Args:
+        account_id: Meta Ads account ID (format: act_XXXXXXXXX)
+        access_token: Meta API access token (optional - will use cached token if not provided)
+    """
+    if not account_id:
+        return json.dumps({"error": "account_id is required"}, indent=2)
+
+    if not account_id.startswith("act_"):
+        account_id = f"act_{account_id}"
+
+    endpoint = f"{account_id}/customaudiences"
+    params = {
+        "fields": "id,name,subtype,approximate_count,data_source,delivery_status"
+    }
+
+    data = await make_api_request(endpoint, access_token, params)
+
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def create_custom_audience(
+    account_id: str,
+    name: str,
+    subtype: str,
+    access_token: Optional[str] = None,
+    description: Optional[str] = None,
+    rule: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    Create a custom audience for a Meta Ads account.
+
+    Args:
+        account_id: Meta Ads account ID (format: act_XXXXXXXXX)
+        name: Audience name
+        subtype: Audience subtype. Valid values: ENGAGEMENT, CUSTOM, WEBSITE, VIDEO, IG_BUSINESS
+        access_token: Meta API access token (optional - will use cached token if not provided)
+        description: Optional audience description
+        rule: Optional rule dict defining audience membership criteria.
+
+    rule examples:
+      IG engagers (30 days): {"inclusions": {"operator": "or", "rules": [{"event_sources": [{"id": "<ig_user_id>", "type": "ig_business"}], "retention_seconds": 2592000, "filter": {"operator": "and", "filters": [{"field": "event", "operator": "eq", "value": "ig_business_profile_all"}]}}]}}
+      Video viewers (60 days): {"inclusions": {"operator": "or", "rules": [{"event_sources": [{"id": "<video_id>", "type": "video"}], "retention_seconds": 5184000, "filter": {"operator": "and", "filters": [{"field": "event", "operator": "eq", "value": "video_watched"}]}}]}}
+    """
+    if not account_id:
+        return json.dumps({"error": "account_id is required"}, indent=2)
+
+    if not name:
+        return json.dumps({"error": "name is required"}, indent=2)
+
+    if not subtype:
+        return json.dumps({"error": "subtype is required"}, indent=2)
+
+    valid_subtypes = {"ENGAGEMENT", "CUSTOM", "WEBSITE", "VIDEO", "IG_BUSINESS"}
+    if subtype not in valid_subtypes:
+        return json.dumps(
+            {"error": f"Invalid subtype '{subtype}'. Valid: ENGAGEMENT, CUSTOM, WEBSITE, VIDEO, IG_BUSINESS"},
+            indent=2,
+        )
+
+    if not account_id.startswith("act_"):
+        account_id = f"act_{account_id}"
+
+    endpoint = f"{account_id}/customaudiences"
+    params: Dict[str, Any] = {
+        "name": name,
+        "subtype": subtype,
+    }
+
+    if description is not None:
+        params["description"] = description
+
+    if rule is not None:
+        params["rule"] = rule
+
+    data = await make_api_request(endpoint, access_token, params, method="POST")
+
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def create_lookalike_audience(
+    account_id: str,
+    name: str,
+    origin_audience_id: str,
+    country: str,
+    access_token: Optional[str] = None,
+    ratio: float = 0.01,
+) -> str:
+    """
+    Create a lookalike audience based on an existing custom audience.
+
+    Args:
+        account_id: Meta Ads account ID (format: act_XXXXXXXXX)
+        name: Audience name
+        origin_audience_id: ID of the source custom audience to base the lookalike on
+        country: Two-letter country code for the lookalike audience (e.g. 'GR', 'US')
+        access_token: Meta API access token (optional - will use cached token if not provided)
+        ratio: Similarity ratio between 0.01 (most similar, 1%) and 0.20 (broadest, 20%). Default: 0.01
+    """
+    if not account_id:
+        return json.dumps({"error": "account_id is required"}, indent=2)
+
+    if not name:
+        return json.dumps({"error": "name is required"}, indent=2)
+
+    if not origin_audience_id:
+        return json.dumps({"error": "origin_audience_id is required"}, indent=2)
+
+    if not country:
+        return json.dumps({"error": "country is required"}, indent=2)
+
+    if not (0.01 <= ratio <= 0.20):
+        return json.dumps(
+            {"error": f"ratio must be between 0.01 and 0.20, got {ratio}"},
+            indent=2,
+        )
+
+    if not account_id.startswith("act_"):
+        account_id = f"act_{account_id}"
+
+    lookalike_spec = {"type": "custom_ratio", "country": country, "ratio": ratio}
+
+    endpoint = f"{account_id}/customaudiences"
+    params: Dict[str, Any] = {
+        "name": name,
+        "subtype": "LOOKALIKE",
+        "origin_audience_id": origin_audience_id,
+        "lookalike_spec": lookalike_spec,
+    }
+
+    data = await make_api_request(endpoint, access_token, params, method="POST")
+
+    return json.dumps(data, indent=2)

--- a/meta_ads_mcp/core/instagram_insights.py
+++ b/meta_ads_mcp/core/instagram_insights.py
@@ -1,0 +1,242 @@
+"""Instagram Insights and publishing functionality for Meta Graph API."""
+
+import json
+from typing import Optional, List
+from .api import meta_api_tool, make_api_request
+from .server import mcp_server
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def list_media(
+    ig_user_id: str,
+    access_token: Optional[str] = None,
+    limit: int = 20,
+) -> str:
+    """List media objects for an Instagram Business Account.
+
+    NOTE: ig_user_id is the Instagram Business Account ID (numeric). Do NOT pass
+    an ad account ID starting with 'act_' — that will fail.
+
+    Args:
+        ig_user_id: Numeric Instagram Business Account ID.
+        access_token: Meta API access token.
+        limit: Maximum number of media items to return (default 20).
+
+    Returns:
+        JSON string with media list including id, media_type, timestamp,
+        permalink, caption, like_count, and comments_count.
+    """
+    if not ig_user_id:
+        return json.dumps({"error": "ig_user_id is required"}, indent=2)
+
+    params = {
+        "fields": "id,media_type,timestamp,permalink,caption,like_count,comments_count",
+        "limit": limit,
+    }
+    data = await make_api_request(f"{ig_user_id}/media", access_token, params)
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def get_media_insights(
+    media_id: str,
+    access_token: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+) -> str:
+    """Get insights for a specific Instagram media object.
+
+    Supported metrics by media type:
+        IMAGE:    impressions, reach, saved, total_interactions
+        VIDEO:    impressions, reach, saved, video_views, total_interactions
+        REELS:    reach, impressions, saved, shares, plays, total_interactions,
+                  ig_reels_aggregated_all_plays_count
+        CAROUSEL: impressions, reach, saved, total_interactions
+
+    Note: The IG API uses the 'metric' parameter (singular), not 'metrics'.
+
+    Args:
+        media_id: ID of the Instagram media object.
+        access_token: Meta API access token.
+        metrics: List of metric names to retrieve. Defaults to
+                 ["reach", "impressions", "saved", "shares", "plays",
+                  "total_interactions"] when None or empty.
+
+    Returns:
+        JSON string with metric data for the media object.
+    """
+    if not media_id:
+        return json.dumps({"error": "media_id is required"}, indent=2)
+
+    default_metrics = ["reach", "impressions", "saved", "shares", "plays", "total_interactions"]
+    metrics_to_use = metrics if metrics else default_metrics
+
+    params = {"metric": ",".join(metrics_to_use)}
+    data = await make_api_request(f"{media_id}/insights", access_token, params)
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def get_ig_account_insights(
+    ig_user_id: str,
+    metrics: List[str],
+    access_token: Optional[str] = None,
+    period: str = "day",
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+) -> str:
+    """Get insights for an Instagram Business Account.
+
+    Note: 'follower_count' metric only works with period=day. Max lookback
+    30 days for most metrics.
+
+    Valid periods: day, week, days_28, month, lifetime.
+
+    Args:
+        ig_user_id: Numeric Instagram Business Account ID.
+        metrics: List of metric names to retrieve (required, must not be empty).
+        access_token: Meta API access token.
+        period: Aggregation period — one of day, week, days_28, month, lifetime.
+        since: Start of date range (YYYY-MM-DD or Unix timestamp). Optional.
+        until: End of date range (YYYY-MM-DD or Unix timestamp). Optional.
+
+    Returns:
+        JSON string with account-level insight data.
+    """
+    if not ig_user_id:
+        return json.dumps({"error": "ig_user_id is required"}, indent=2)
+
+    if not metrics:
+        return json.dumps({"error": "metrics must not be empty"}, indent=2)
+
+    valid_periods = {"day", "week", "days_28", "month", "lifetime"}
+    if period not in valid_periods:
+        return json.dumps(
+            {"error": f"Invalid period '{period}'. Valid: day, week, days_28, month, lifetime"},
+            indent=2,
+        )
+
+    params = {
+        "metric": ",".join(metrics),
+        "period": period,
+    }
+    if since is not None:
+        params["since"] = since
+    if until is not None:
+        params["until"] = until
+
+    data = await make_api_request(f"{ig_user_id}/insights", access_token, params)
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def get_story_insights(
+    story_id: str,
+    access_token: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+) -> str:
+    """Get insights for an Instagram Story.
+
+    Note: Story insights are only available ~72h after posting (24h story
+    lifetime + 48h after expiry before metrics stabilise).
+
+    Args:
+        story_id: ID of the Instagram Story media object.
+        access_token: Meta API access token.
+        metrics: List of metric names to retrieve. Defaults to
+                 ["impressions", "reach", "replies", "taps_forward",
+                  "taps_back", "exits"] when None or empty.
+
+    Returns:
+        JSON string with story insight data.
+    """
+    if not story_id:
+        return json.dumps({"error": "story_id is required"}, indent=2)
+
+    default_metrics = ["impressions", "reach", "replies", "taps_forward", "taps_back", "exits"]
+    metrics_to_use = metrics if metrics else default_metrics
+
+    params = {"metric": ",".join(metrics_to_use)}
+    data = await make_api_request(f"{story_id}/insights", access_token, params)
+    return json.dumps(data, indent=2)
+
+
+@mcp_server.tool()
+@meta_api_tool
+async def publish_media(
+    ig_user_id: str,
+    media_url: str,
+    media_type: str,
+    access_token: Optional[str] = None,
+    caption: Optional[str] = None,
+) -> str:
+    """Publish a media object to an Instagram Business Account (two-step process).
+
+    Step 1 creates a media container; Step 2 publishes it. If Step 1 fails,
+    the error is returned immediately without attempting Step 2.
+
+    Note: 50 posts/day rate limit applies. Media URL must be publicly accessible.
+
+    Valid media_type values: IMAGE, VIDEO, REELS, STORIES.
+
+    Args:
+        ig_user_id: Numeric Instagram Business Account ID.
+        media_url: Publicly accessible URL of the media to publish.
+        media_type: One of IMAGE, VIDEO, REELS, STORIES.
+        access_token: Meta API access token.
+        caption: Optional caption text for the post.
+
+    Returns:
+        JSON string with the published media ID on success, or an error dict.
+    """
+    if not ig_user_id:
+        return json.dumps({"error": "ig_user_id is required"}, indent=2)
+
+    if not media_url.startswith("http://") and not media_url.startswith("https://"):
+        return json.dumps({"error": "media_url must start with http:// or https://"}, indent=2)
+
+    valid_media_types = {"IMAGE", "VIDEO", "REELS", "STORIES"}
+    if media_type not in valid_media_types:
+        return json.dumps(
+            {"error": f"Invalid media_type '{media_type}'. Valid: IMAGE, VIDEO, REELS, STORIES"},
+            indent=2,
+        )
+
+    # Step 1 — Create media container
+    step1_params = {"caption": caption} if caption else {}
+    if media_type == "IMAGE":
+        step1_params["image_url"] = media_url
+    else:  # VIDEO, REELS, STORIES
+        step1_params["video_url"] = media_url
+        step1_params["media_type"] = media_type
+
+    step1_data = await make_api_request(
+        f"{ig_user_id}/media", access_token, step1_params, method="POST"
+    )
+
+    if "error" in step1_data:
+        return json.dumps(step1_data, indent=2)
+
+    creation_id = step1_data.get("id")
+    if not creation_id:
+        return json.dumps(
+            {"error": "Step 1 succeeded but no creation_id returned", "step1_response": step1_data},
+            indent=2,
+        )
+
+    # Step 2 — Publish the container
+    step2_params = {"creation_id": creation_id}
+    step2_data = await make_api_request(
+        f"{ig_user_id}/media_publish", access_token, step2_params, method="POST"
+    )
+
+    if "error" in step2_data:
+        return json.dumps(
+            {"error": "Publishing failed", "creation_id": creation_id, "details": step2_data},
+            indent=2,
+        )
+
+    return json.dumps(step2_data, indent=2)

--- a/tests/test_audiences.py
+++ b/tests/test_audiences.py
@@ -1,0 +1,229 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, patch
+
+from meta_ads_mcp.core.audiences import (
+    get_custom_audiences,
+    create_custom_audience,
+    create_lookalike_audience,
+)
+
+
+class TestGetCustomAudiences:
+    """Test cases for get_custom_audiences function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Test successful retrieval of custom audiences."""
+        mock_response = {
+            "data": [
+                {
+                    "id": "123",
+                    "name": "Test Audience",
+                    "subtype": "ENGAGEMENT",
+                    "approximate_count": 1000,
+                }
+            ]
+        }
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await get_custom_audiences(
+                account_id="act_123456789", access_token="test_token"
+            )
+
+            mock_api.assert_called_once_with(
+                "act_123456789/customaudiences",
+                "test_token",
+                {"fields": "id,name,subtype,approximate_count,data_source,delivery_status"},
+            )
+
+            result_data = json.loads(result)
+            assert result_data["data"][0]["name"] == "Test Audience"
+
+    @pytest.mark.asyncio
+    async def test_no_account_id(self):
+        """Test that an empty account_id returns an error."""
+        result = await get_custom_audiences(account_id="", access_token="test_token")
+
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+    @pytest.mark.asyncio
+    async def test_act_prefix_normalization(self):
+        """Test that account_id without act_ prefix is normalized."""
+        mock_response = {"data": []}
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            await get_custom_audiences(
+                account_id="123456789", access_token="test_token"
+            )
+
+            mock_api.assert_called_once_with(
+                "act_123456789/customaudiences",
+                "test_token",
+                {"fields": "id,name,subtype,approximate_count,data_source,delivery_status"},
+            )
+
+
+class TestCreateCustomAudience:
+    """Test cases for create_custom_audience function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Test successful creation of a custom audience."""
+        mock_response = {"id": "audience_123"}
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await create_custom_audience(
+                account_id="act_123",
+                name="My Audience",
+                subtype="ENGAGEMENT",
+                access_token="test_token",
+            )
+
+            # Verify a POST call was made to the correct endpoint
+            call_args = mock_api.call_args
+            assert call_args[0][0] == "act_123/customaudiences"
+            assert call_args[1].get("method") == "POST" or (
+                len(call_args[0]) > 3 and call_args[0][3] == "POST"
+            )
+
+            result_data = json.loads(result)
+            assert result_data["id"] == "audience_123"
+
+    @pytest.mark.asyncio
+    async def test_with_rule_dict(self):
+        """Test that a rule dict is passed through to make_api_request."""
+        mock_response = {"id": "audience_456"}
+        rule = {"inclusions": {"operator": "or", "rules": []}}
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            await create_custom_audience(
+                account_id="act_123",
+                name="My Audience",
+                subtype="ENGAGEMENT",
+                access_token="test_token",
+                rule=rule,
+            )
+
+            call_args = mock_api.call_args
+            # params is the third positional arg
+            params = call_args[0][2]
+            assert params["rule"] == rule
+
+    @pytest.mark.asyncio
+    async def test_missing_name(self):
+        """Test that an empty name returns an error."""
+        result = await create_custom_audience(
+            account_id="act_123",
+            name="",
+            subtype="ENGAGEMENT",
+            access_token="test_token",
+        )
+
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+    @pytest.mark.asyncio
+    async def test_invalid_subtype(self):
+        """Test that an invalid subtype returns an error."""
+        result = await create_custom_audience(
+            account_id="act_123",
+            name="My Audience",
+            subtype="INVALID_TYPE",
+            access_token="test_token",
+        )
+
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+
+class TestCreateLookalikeAudience:
+    """Test cases for create_lookalike_audience function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Test successful creation of a lookalike audience."""
+        mock_response = {"id": "lookalike_456"}
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await create_lookalike_audience(
+                account_id="act_123",
+                name="Lookalike",
+                origin_audience_id="audience_123",
+                country="GR",
+                access_token="test_token",
+            )
+
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            assert params["lookalike_spec"]["country"] == "GR"
+            assert params["lookalike_spec"]["ratio"] == 0.01
+
+            result_data = json.loads(result)
+            assert result_data["id"] == "lookalike_456"
+
+    @pytest.mark.asyncio
+    async def test_default_ratio(self):
+        """Test that the default ratio is 0.01."""
+        mock_response = {"id": "lookalike_789"}
+
+        with patch(
+            "meta_ads_mcp.core.audiences.make_api_request", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = mock_response
+
+            await create_lookalike_audience(
+                account_id="act_123",
+                name="Lookalike",
+                origin_audience_id="audience_123",
+                country="GR",
+                access_token="test_token",
+            )
+
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            assert params["lookalike_spec"]["ratio"] == 0.01
+
+    @pytest.mark.asyncio
+    async def test_invalid_ratio_too_high(self):
+        """Test that a ratio above 0.20 returns an error."""
+        result = await create_lookalike_audience(
+            account_id="act_123",
+            name="Lookalike",
+            origin_audience_id="audience_123",
+            country="GR",
+            access_token="test_token",
+            ratio=0.5,
+        )
+
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested

--- a/tests/test_instagram_insights.py
+++ b/tests/test_instagram_insights.py
@@ -1,0 +1,248 @@
+"""Tests for instagram_insights module."""
+
+import pytest
+import json
+from unittest.mock import AsyncMock, patch, call
+
+from meta_ads_mcp.core.instagram_insights import (
+    list_media,
+    get_media_insights,
+    get_ig_account_insights,
+    get_story_insights,
+    publish_media,
+)
+
+
+class TestListMedia:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        mock_response = {"data": [{"id": "123", "media_type": "REELS", "like_count": 50}]}
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api:
+            result = await list_media(ig_user_id="17841400000", access_token="test_token")
+            mock_api.assert_called_once_with(
+                "17841400000/media",
+                "test_token",
+                {
+                    "fields": "id,media_type,timestamp,permalink,caption,like_count,comments_count",
+                    "limit": 20,
+                },
+            )
+            result_data = json.loads(result)
+            assert result_data["data"][0]["id"] == "123"
+            assert result_data["data"][0]["media_type"] == "REELS"
+            assert result_data["data"][0]["like_count"] == 50
+
+    @pytest.mark.asyncio
+    async def test_no_ig_user_id(self):
+        result = await list_media(ig_user_id="", access_token="test_token")
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+
+class TestGetMediaInsights:
+    @pytest.mark.asyncio
+    async def test_success_with_defaults(self):
+        mock_response = {"data": [{"name": "reach", "values": [{"value": 500}]}]}
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api:
+            result = await get_media_insights(media_id="123", access_token="test_token")
+            # Confirm metric param is the default comma-joined string
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            default_metrics = ["reach", "impressions", "saved", "shares", "plays", "total_interactions"]
+            assert params["metric"] == ",".join(default_metrics)
+            result_data = json.loads(result)
+            assert result_data["data"][0]["name"] == "reach"
+
+    @pytest.mark.asyncio
+    async def test_custom_metrics(self):
+        mock_response = {"data": []}
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api:
+            await get_media_insights(
+                media_id="123",
+                access_token="test_token",
+                metrics=["reach", "impressions"],
+            )
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            assert params["metric"] == "reach,impressions"
+
+    @pytest.mark.asyncio
+    async def test_no_media_id(self):
+        result = await get_media_insights(media_id="", access_token="test_token")
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+
+class TestGetIgAccountInsights:
+    @pytest.mark.asyncio
+    async def test_success_with_since_until(self):
+        mock_response = {"data": []}
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api:
+            result = await get_ig_account_insights(
+                ig_user_id="17841400000",
+                metrics=["follower_count"],
+                period="day",
+                since="2026-03-01",
+                until="2026-03-11",
+                access_token="test_token",
+            )
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            assert params["since"] == "2026-03-01"
+            assert params["until"] == "2026-03-11"
+            result_data = json.loads(result)
+            assert "data" in result_data
+
+    @pytest.mark.asyncio
+    async def test_invalid_period(self):
+        result = await get_ig_account_insights(
+            ig_user_id="17841400000",
+            metrics=["follower_count"],
+            period="quarterly",
+            access_token="test_token",
+        )
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+    @pytest.mark.asyncio
+    async def test_no_metrics(self):
+        result = await get_ig_account_insights(
+            ig_user_id="17841400000",
+            metrics=[],
+            period="day",
+            access_token="test_token",
+        )
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+
+class TestGetStoryInsights:
+    @pytest.mark.asyncio
+    async def test_success_with_defaults(self):
+        mock_response = {"data": [{"name": "impressions", "values": [{"value": 200}]}]}
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api:
+            result = await get_story_insights(story_id="story_123", access_token="test_token")
+            call_args = mock_api.call_args
+            params = call_args[0][2]
+            default_metrics = ["impressions", "reach", "replies", "taps_forward", "taps_back", "exits"]
+            assert params["metric"] == ",".join(default_metrics)
+            result_data = json.loads(result)
+            assert result_data["data"][0]["name"] == "impressions"
+            assert result_data["data"][0]["values"][0]["value"] == 200
+
+
+class TestPublishMedia:
+    @pytest.mark.asyncio
+    async def test_two_step_success(self):
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+        ) as mock_api:
+            mock_api.side_effect = [{"id": "container_123"}, {"id": "published_456"}]
+            result = await publish_media(
+                ig_user_id="17841400000",
+                media_url="https://example.com/video.mp4",
+                media_type="REELS",
+                access_token="test_token",
+            )
+            assert mock_api.call_count == 2
+            result_data = json.loads(result)
+            assert result_data["id"] == "published_456"
+
+    @pytest.mark.asyncio
+    async def test_invalid_media_url(self):
+        result = await publish_media(
+            ig_user_id="17841400000",
+            media_url="ftp://not-valid",
+            media_type="REELS",
+            access_token="test_token",
+        )
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+    @pytest.mark.asyncio
+    async def test_invalid_media_type(self):
+        result = await publish_media(
+            ig_user_id="17841400000",
+            media_url="https://example.com/image.jpg",
+            media_type="CAROUSEL",
+            access_token="test_token",
+        )
+        result_data = json.loads(result)
+        assert "data" in result_data
+        nested = json.loads(result_data["data"])
+        assert "error" in nested
+
+    @pytest.mark.asyncio
+    async def test_step1_failure(self):
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+            return_value={"error": {"message": "Upload failed"}},
+        ) as mock_api:
+            result = await publish_media(
+                ig_user_id="17841400000",
+                media_url="https://example.com/video.mp4",
+                media_type="REELS",
+                access_token="test_token",
+            )
+            # Only one call should be made — step 2 must not run
+            assert mock_api.call_count == 1
+            result_data = json.loads(result)
+            assert "data" in result_data
+            nested = json.loads(result_data["data"])
+            assert "error" in nested
+            # creation_id must NOT be in the response (step 1 failed cleanly)
+            assert "creation_id" not in nested
+
+    @pytest.mark.asyncio
+    async def test_step2_failure(self):
+        with patch(
+            "meta_ads_mcp.core.instagram_insights.make_api_request",
+            new_callable=AsyncMock,
+        ) as mock_api:
+            mock_api.side_effect = [
+                {"id": "container_123"},
+                {"error": {"message": "Publish failed"}},
+            ]
+            result = await publish_media(
+                ig_user_id="17841400000",
+                media_url="https://example.com/video.mp4",
+                media_type="REELS",
+                access_token="test_token",
+            )
+            result_data = json.loads(result)
+            assert "error" in result_data
+            # creation_id must be present so the caller can debug
+            assert "creation_id" in result_data
+            assert result_data["creation_id"] == "container_123"


### PR DESCRIPTION
## Summary

- **`audiences.py`** — 3 tools for Custom Audiences: `get_custom_audiences`, `create_custom_audience` (with subtype validation), `create_lookalike_audience` (ratio validated 0.01–0.20)
- **`instagram_insights.py`** — 5 tools: `list_media`, `get_media_insights` (per-type metric docs), `get_ig_account_insights` (period + since/until), `get_story_insights`, `publish_media` (two-step container→publish with `creation_id` surfaced on step-2 failure)
- **`__init__.py`** — wired all 8 tools into the package exports

All tools follow the existing `@mcp_server.tool()` + `@meta_api_tool` decorator pattern and `make_api_request` conventions.

## Test plan

- [x] 24 unit tests added (`tests/test_audiences.py`, `tests/test_instagram_insights.py`)
- [x] All 24 pass: `pytest tests/test_audiences.py tests/test_instagram_insights.py -v`
- [x] Package imports cleanly (`import meta_ads_mcp`)
- [ ] Live smoke test pending credentials: `get_custom_audiences`, `list_media`, `get_media_insights`

🤖 Generated with [Claude Code](https://claude.com/claude-code)