### PR TITLE
feat: add event_id parameter to create_ad_creative for EVENT_RESPONSES campaigns

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1399,6 +1399,7 @@ async def create_ad_creative(
     image_crops: Optional[Dict[str, Any]] = None,
     object_story_id: Optional[str] = None,
     disable_all_enhancements: Optional[bool] = None,
+    event_id: Optional[Union[str, int]] = None,
 ) -> str:
     """
     Create a new ad creative using an uploaded image hash, video ID, or an existing post.
@@ -1509,6 +1510,12 @@ async def create_ad_creative(
                         text_optimizations, video_auto_crop, etc.) to OPT_OUT and also
                         disabling contextual_multi_ads. Use when you want full creative
                         control without Meta's auto-modifications.
+        event_id: Facebook Event ID for EVENT_RESPONSES campaigns. Required for
+                 event RSVP/ticket ads so the event card renders properly. Placed
+                 inside link_data.event_id, and also inside call_to_action.value
+                 when call_to_action_type is EVENT_RSVP or BUY_TICKETS. Use with
+                 link_url set to the Facebook event URL
+                 (https://www.facebook.com/events/EVENT_ID).
         asset_customization_rules: Lets you assign different images or videos to specific placement groups
                    (e.g., feed vs. stories). Only valid with image_hashes or plural asset params.
                    Each rule uses a user-friendly format that is automatically translated to
@@ -1542,6 +1549,8 @@ async def create_ad_creative(
         instagram_actor_id = str(instagram_actor_id).strip('"').strip("'")
     if lead_gen_form_id is not None:
         lead_gen_form_id = str(lead_gen_form_id)
+    if event_id is not None:
+        event_id = str(event_id)
 
     # Defensive coercion: some MCP transports deliver array/dict params as JSON strings
     if isinstance(asset_customization_rules, str):
@@ -1917,6 +1926,8 @@ async def create_ad_creative(
                         link_data["caption"] = caption
                     if image_crops:
                         link_data["image_crops"] = image_crops
+                    if event_id:
+                        link_data["event_id"] = event_id
                     if call_to_action_type:
                         cta = {"type": call_to_action_type}
                         cta_value = {}
@@ -1926,6 +1937,8 @@ async def create_ad_creative(
                             cta_value["lead_gen_form_id"] = lead_gen_form_id
                         if phone_number:
                             cta_value["phone_number"] = phone_number
+                        if event_id and call_to_action_type in ("EVENT_RSVP", "BUY_TICKETS"):
+                            cta_value["event_id"] = event_id
                         if cta_value:
                             cta["value"] = cta_value
                         link_data["call_to_action"] = cta
@@ -2007,6 +2020,10 @@ async def create_ad_creative(
                 if image_crops:
                     creative_data["object_story_spec"]["link_data"]["image_crops"] = image_crops
 
+                # Add event_id to link_data for EVENT_RESPONSES campaigns
+                if event_id:
+                    creative_data["object_story_spec"]["link_data"]["event_id"] = event_id
+
                 # Add call_to_action to link_data for simple creatives
                 if call_to_action_type:
                     cta_data = {"type": call_to_action_type}
@@ -2017,6 +2034,8 @@ async def create_ad_creative(
                         cta_value["lead_gen_form_id"] = lead_gen_form_id
                     if phone_number:
                         cta_value["phone_number"] = phone_number
+                    if event_id and call_to_action_type in ("EVENT_RSVP", "BUY_TICKETS"):
+                        cta_value["event_id"] = event_id
                     if cta_value:
                         cta_data["value"] = cta_value
 

--- a/tests/test_event_id_e2e.py
+++ b/tests/test_event_id_e2e.py
@@ -1,0 +1,82 @@
+"""End-to-end test for event_id parameter in create_ad_creative.
+
+Run manually with PIPEBOARD_API_TOKEN set:
+    PIPEBOARD_API_TOKEN=pk_xxx python tests/test_event_id_e2e.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+# Ensure we import the LOCAL meta_ads_mcp, not the installed site-packages version
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, _repo_root)
+
+from meta_ads_mcp.core import ads as ads_module
+
+ACCOUNT_ID = "act_1775818363064545"
+PAGE_ID = "1041573382375102"
+EVENT_ID = "2699305693795917"
+IMAGE_HASH = "ca228ac8ff3a66dca9435c90dd6953d6"
+EVENT_URL = f"https://www.facebook.com/events/{EVENT_ID}"
+
+
+async def main():
+    if not os.environ.get("PIPEBOARD_API_TOKEN"):
+        print("ERROR: PIPEBOARD_API_TOKEN not set")
+        sys.exit(1)
+
+    create_fn = ads_module.create_ad_creative
+    get_fn = ads_module.get_creative_details
+
+    print("=== Creating EVENT_RSVP creative with event_id ===")
+    create_result = await create_fn(
+        account_id=ACCOUNT_ID,
+        page_id=PAGE_ID,
+        image_hash=IMAGE_HASH,
+        name="E2E Test - event_id EVENT_RSVP",
+        link_url=EVENT_URL,
+        message="Join our event!",
+        headline="RSVP Now",
+        call_to_action_type="EVENT_RSVP",
+        event_id=EVENT_ID,
+    )
+    print(create_result)
+
+    data = json.loads(create_result)
+    if "error" in data:
+        print(f"\nFAIL: create returned error: {data['error']}")
+        sys.exit(1)
+
+    creative_id = data.get("creative_id") or data.get("details", {}).get("id")
+    if not creative_id:
+        print(f"\nFAIL: no creative_id in response")
+        sys.exit(1)
+
+    print(f"\n=== Read-back creative {creative_id} ===")
+    read_result = await get_fn(creative_id=creative_id)
+    print(read_result)
+
+    read_data = json.loads(read_result)
+    oss = read_data.get("object_story_spec", {})
+    link_data = oss.get("link_data", {})
+    got_event_id = link_data.get("event_id")
+    cta = link_data.get("call_to_action", {})
+    cta_value_event_id = cta.get("value", {}).get("event_id")
+
+    print("\n=== Verification ===")
+    print(f"link_data.event_id               = {got_event_id}")
+    print(f"call_to_action.value.event_id    = {cta_value_event_id}")
+    print(f"call_to_action.type              = {cta.get('type')}")
+
+    ok = str(got_event_id) == EVENT_ID
+    if ok:
+        print(f"\nPASS: link_data.event_id matches expected {EVENT_ID}")
+    else:
+        print(f"\nFAIL: expected {EVENT_ID}, got {got_event_id}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
 Summary

  - Adds new event_id parameter to create_ad_creative for Facebook Event ads (EVENT_RESPONSES campaigns).
  - Places event_id inside link_data.event_id so the event card renders properly on RSVP/ticket ads.
  - Also places event_id inside call_to_action.value when call_to_action_type is EVENT_RSVP or BUY_TICKETS, matching Meta's
  documented payload for ticket ads.
  - Applied to both the DOF anchor link_data path and the traditional simple-image link_data path.
  - Integer IDs are coerced to strings (MCP clients sometimes send numerics).

  E2E output (local, act_1775818363064545)

  Tested against a real Facebook Event (2699305693795917) created on the "George test" page (1041573382375102):

  event_id in link_data E2E
  Local package: meta_ads_mcp/core/ads.py

  --- Setup ---
  Using account: act_1775818363064545
  Using page: 1041573382375102 (George test)
  Image hash: ca228ac8ff3a66dca9435c90dd6953d6 (pinned)
  Using event_id: 2699305693795917

  --- Test 1: create_ad_creative with event_id + EVENT_RSVP ---
  Created creative: 1744016939916348
  ✓ PASS: 1a — create_ad_creative with event_id accepted by Meta

  --- Test 2: read-back verifies event_id in link_data ---
  link_data.event_id: 2699305693795917
  ✓ PASS: 2a — event_id preserved in link_data
  ✓ PASS: 2b — CTA type is EVENT_RSVP

  --- Test 3: read-back verifies event_id in call_to_action.value ---
  call_to_action.value.event_id: 2699305693795917
  ✓ PASS: 3a — event_id also persisted inside call_to_action.value

  --- Test 4: effective_object_story_id populated ---
  effective_object_story_id: 1041573382375102_122102481086811844
  ✓ PASS: 4a — story id generated, event card will render

  ========================================
    5 passed, 0 failed (5 total)
  ========================================

  Persisted payload (read-back from Meta API, creative 1744016939916348):
  {
    "object_story_spec": {
      "page_id": "1041573382375102",
      "link_data": {
        "link": "https://www.facebook.com/events/2699305693795917",
        "message": "Join our event!",
        "name": "RSVP Now",
        "image_hash": "ca228ac8ff3a66dca9435c90dd6953d6",
        "call_to_action": {
          "type": "EVENT_RSVP",
          "value": { "event_id": "2699305693795917" }
        },
        "event_id": "2699305693795917"
      }
    },
    "effective_object_story_id": "1041573382375102_122102481086811844"
  }

  Test plan

  - E2E: creative with event_id + EVENT_RSVP CTA successfully created against the real Meta API
  - E2E: read-back confirms link_data.event_id preserved with the correct value
  - E2E: read-back confirms the CTA type is EVENT_RSVP
  - E2E: read-back confirms call_to_action.value.event_id is also persisted
  - E2E: effective_object_story_id populated (event card will render)