### PR TITLE
Add reminder_data support for Instagram Reminder Ads

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1400,6 +1400,7 @@ async def create_ad_creative(
     object_story_id: Optional[str] = None,
     disable_all_enhancements: Optional[bool] = None,
     event_id: Optional[Union[str, int]] = None,
+    reminder_data: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Create a new ad creative using an uploaded image hash, video ID, or an existing post.
@@ -1421,7 +1422,7 @@ async def create_ad_creative(
         access_token: Meta API access token (optional - will use cached token if not provided)
         name: Creative name
         page_id: Facebook Page ID (string or int; coerced to string)
-        link_url: Destination URL for the ad (required unless using lead_gen_form_id)
+        link_url: Destination URL for the ad (required unless using lead_gen_form_id or reminder_data)
         message: Single ad copy/text (cannot be used with messages)
         messages: List of primary text variants for multi-variant copy testing (cannot be used with message)
         headline: Single headline for simple ads (cannot be used with headlines)
@@ -1534,6 +1535,19 @@ async def create_ad_creative(
                      {"placement_groups": ["STORY"],
                       "customization_spec": {"image_hashes": ["<story_hash>"]}}
                    ]
+        reminder_data: Inline reminder event data for Instagram Reminder Ads
+                      (REMINDERS_SET optimization goal). Placed in
+                      object_story_spec.link_data.reminder_data. Use this instead of
+                      upcoming_events (which requires an existing ig_upcoming_event_id).
+                      Required fields:
+                        - event_name (str): Display title of the reminder event
+                        - start_time (int): Event start as a Unix timestamp (seconds)
+                        - end_time (int): Event end as a Unix timestamp (seconds)
+                      Example:
+                        {"event_name": "Summer Sale", "start_time": 1745596800, "end_time": 1745611200}
+                      The ad set must use optimization_goal=REMINDERS_SET and the placement
+                      must be restricted to Instagram feeds/stories. link_url is still
+                      recommended (the URL users visit after the reminder fires).
 
     Returns:
         JSON response with created creative details
@@ -1574,6 +1588,14 @@ async def create_ad_creative(
             _parsed = json.loads(image_crops)
             if isinstance(_parsed, dict):
                 image_crops = _parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if isinstance(reminder_data, str):
+        try:
+            _parsed = json.loads(reminder_data)
+            if isinstance(_parsed, dict):
+                reminder_data = _parsed
         except (json.JSONDecodeError, TypeError):
             pass
 
@@ -1639,8 +1661,8 @@ async def create_ad_creative(
     if message and messages:
         return json.dumps({"error": "Cannot specify both 'message' and 'messages'. Use 'message' for single text or 'messages' for multiple variants."}, indent=2)
     
-    if not link_url and not lead_gen_form_id and not object_story_id:
-        return json.dumps({"error": "No link_url provided. A destination URL is required for ad creatives (unless using lead_gen_form_id or object_story_id)."}, indent=2)
+    if not link_url and not lead_gen_form_id and not object_story_id and not reminder_data:
+        return json.dumps({"error": "No link_url provided. A destination URL is required for ad creatives (unless using lead_gen_form_id, object_story_id, or reminder_data)."}, indent=2)
 
     if not name:
         name = f"Creative {int(time.time())}"
@@ -1917,7 +1939,9 @@ async def create_ad_creative(
                     }
                 else:
                     # DOF: link_data serves as the "anchor" creative template.
-                    link_data = {"link": link_url}
+                    link_data = {}
+                    if link_url:
+                        link_data["link"] = link_url
                     if image_hashes:
                         link_data["image_hash"] = image_hashes[0]
                     elif image_hash:
@@ -1928,6 +1952,8 @@ async def create_ad_creative(
                         link_data["image_crops"] = image_crops
                     if event_id:
                         link_data["event_id"] = event_id
+                    if reminder_data:
+                        link_data["reminder_data"] = reminder_data
                     if call_to_action_type:
                         cta = {"type": call_to_action_type}
                         cta_value = {}
@@ -1992,12 +2018,15 @@ async def create_ad_creative(
                 }
             else:
                 # Use traditional object_story_spec with link_data for simple image creatives
+                link_data: Dict[str, Any] = {
+                    "image_hash": image_hash,
+                }
+                if link_url:
+                    link_data["link"] = link_url
+
                 creative_data["object_story_spec"] = {
                     "page_id": page_id,
-                    "link_data": {
-                        "image_hash": image_hash,
-                        "link": link_url
-                    }
+                    "link_data": link_data,
                 }
 
                 # Add optional parameters if provided
@@ -2023,6 +2052,12 @@ async def create_ad_creative(
                 # Add event_id to link_data for EVENT_RESPONSES campaigns
                 if event_id:
                     creative_data["object_story_spec"]["link_data"]["event_id"] = event_id
+
+                # Add reminder_data to link_data for Instagram Reminder Ads (REMINDERS_SET goal).
+                # The event details (name, start/end timestamps) are set inline rather than
+                # linking to an existing FB event via upcoming_events/ig_upcoming_event_id.
+                if reminder_data:
+                    creative_data["object_story_spec"]["link_data"]["reminder_data"] = reminder_data
 
                 # Add call_to_action to link_data for simple creatives
                 if call_to_action_type:

--- a/tests/test_reminder_ads.py
+++ b/tests/test_reminder_ads.py
@@ -1,0 +1,198 @@
+"""
+Tests for Instagram Reminder Ads support (REMINDERS_SET optimization goal).
+
+Reminder Ads use reminder_data inside object_story_spec.link_data to define
+an inline event (name, start_time, end_time) without requiring an existing
+FB event / ig_upcoming_event_id.
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from meta_ads_mcp.core.ads import create_ad_creative
+
+
+REMINDER = {
+    "event_name": "Summer Sale",
+    "start_time": 1745596800,
+    "end_time": 1745611200,
+}
+
+
+def _mock_discovery():
+    return {"success": True, "page_id": "123456789", "page_name": "Test Page"}
+
+
+def _mock_api_responses(creative_id="creative_reminder_1"):
+    return [
+        {"id": creative_id},
+        {"id": creative_id, "name": "Reminder Ad", "status": "ACTIVE"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Simple image creative (no asset_feed_spec)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reminder_data_in_simple_image_link_data():
+    """reminder_data is placed inside object_story_spec.link_data for a simple image creative."""
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, \
+         patch("meta_ads_mcp.core.ads._discover_pages_for_account") as mock_discover:
+
+        mock_discover.return_value = _mock_discovery()
+        mock_api.side_effect = _mock_api_responses()
+
+        result = await create_ad_creative(
+            account_id="act_123456789",
+            image_hash="test_hash_abc",
+            name="IG Reminder Ad",
+            link_url="https://example.com/sale",
+            message="Don't miss our sale!",
+            reminder_data=REMINDER,
+            access_token="test_token",
+        )
+
+        data = json.loads(result)
+        assert data.get("success") is True
+
+        create_call_args = mock_api.call_args_list[0]
+        creative_data = create_call_args[0][2]
+
+        # Must use object_story_spec, not asset_feed_spec
+        assert "object_story_spec" in creative_data
+        assert "asset_feed_spec" not in creative_data
+
+        link_data = creative_data["object_story_spec"]["link_data"]
+        assert "reminder_data" in link_data, "reminder_data must be in link_data"
+        assert link_data["reminder_data"]["event_name"] == "Summer Sale"
+        assert link_data["reminder_data"]["start_time"] == 1745596800
+        assert link_data["reminder_data"]["end_time"] == 1745611200
+
+        # Other link_data fields must still be present
+        assert link_data["image_hash"] == "test_hash_abc"
+        assert link_data["link"] == "https://example.com/sale"
+
+
+@pytest.mark.asyncio
+async def test_reminder_data_without_link_url():
+    """reminder_data can be used without link_url (link_url is optional when reminder_data is provided)."""
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, \
+         patch("meta_ads_mcp.core.ads._discover_pages_for_account") as mock_discover:
+
+        mock_discover.return_value = _mock_discovery()
+        mock_api.side_effect = _mock_api_responses()
+
+        result = await create_ad_creative(
+            account_id="act_123456789",
+            image_hash="test_hash_abc",
+            name="IG Reminder No URL",
+            reminder_data=REMINDER,
+            access_token="test_token",
+        )
+
+        data = json.loads(result)
+        # Should not fail with "No link_url provided" error
+        assert "error" not in data or "No link_url" not in data.get("error", "")
+        assert data.get("success") is True
+
+        create_call_args = mock_api.call_args_list[0]
+        creative_data = create_call_args[0][2]
+        link_data = creative_data["object_story_spec"]["link_data"]
+
+        assert "reminder_data" in link_data
+        # link field should not be present when link_url was not provided
+        assert "link" not in link_data
+
+
+@pytest.mark.asyncio
+async def test_reminder_data_as_json_string_is_coerced():
+    """reminder_data passed as a JSON string (some MCP transports) is coerced to a dict."""
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, \
+         patch("meta_ads_mcp.core.ads._discover_pages_for_account") as mock_discover:
+
+        mock_discover.return_value = _mock_discovery()
+        mock_api.side_effect = _mock_api_responses()
+
+        reminder_json_str = json.dumps(REMINDER)
+
+        result = await create_ad_creative(
+            account_id="act_123456789",
+            image_hash="test_hash_abc",
+            name="IG Reminder JSON String",
+            link_url="https://example.com/sale",
+            reminder_data=reminder_json_str,  # type: ignore[arg-type]
+            access_token="test_token",
+        )
+
+        data = json.loads(result)
+        assert data.get("success") is True
+
+        create_call_args = mock_api.call_args_list[0]
+        creative_data = create_call_args[0][2]
+        link_data = creative_data["object_story_spec"]["link_data"]
+
+        assert isinstance(link_data["reminder_data"], dict)
+        assert link_data["reminder_data"]["event_name"] == "Summer Sale"
+
+
+@pytest.mark.asyncio
+async def test_no_reminder_data_does_not_inject_field():
+    """When reminder_data is not provided, link_data must NOT contain a reminder_data key."""
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, \
+         patch("meta_ads_mcp.core.ads._discover_pages_for_account") as mock_discover:
+
+        mock_discover.return_value = _mock_discovery()
+        mock_api.side_effect = [
+            {"id": "creative_regular"},
+            {"id": "creative_regular", "name": "Regular Ad", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456789",
+            image_hash="test_hash_abc",
+            name="Regular Image Ad",
+            link_url="https://example.com/page",
+            message="Check this out",
+            access_token="test_token",
+        )
+
+        data = json.loads(result)
+        assert data.get("success") is True
+
+        create_call_args = mock_api.call_args_list[0]
+        creative_data = create_call_args[0][2]
+        link_data = creative_data["object_story_spec"]["link_data"]
+
+        assert "reminder_data" not in link_data
+
+
+# ---------------------------------------------------------------------------
+# Missing link_url without reminder_data still returns an error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_link_url_without_reminder_data_returns_error():
+    """Omitting both link_url and reminder_data (and lead_gen_form_id) should still error."""
+    with patch("meta_ads_mcp.core.ads._discover_pages_for_account") as mock_discover:
+        mock_discover.return_value = _mock_discovery()
+
+        result = await create_ad_creative(
+            account_id="act_123456789",
+            image_hash="test_hash_abc",
+            name="Bad Ad",
+            access_token="test_token",
+            # No link_url, no lead_gen_form_id, no reminder_data
+        )
+
+        # The @meta_api_tool decorator may wrap the error JSON in a "data" key.
+        outer = json.loads(result)
+        if "data" in outer:
+            error_data = json.loads(outer["data"])
+        else:
+            error_data = outer
+        assert "error" in error_data
+        assert "link_url" in error_data["error"]


### PR DESCRIPTION
## Summary

- Added `reminder_data` parameter to `create_ad_creative`. When provided, the field is placed directly inside `object_story_spec.link_data.reminder_data` for inline Instagram Reminder Ads (REMINDERS_SET optimization goal).
- This approach does NOT require an existing Facebook/Instagram event ID — the event is defined inline with `event_name` (string), `start_time` (Unix timestamp), and `end_time` (Unix timestamp).
- `link_url` is now optional when `reminder_data` is provided (same as `lead_gen_form_id`).
- JSON string coercion: if `reminder_data` is passed as a JSON string (some MCP transports), it is parsed to a dict.

## Test plan

- [x] 5 new unit tests in `tests/test_reminder_ads.py`
- [x] All 419 tests pass