### PR TITLE
Revert account_id param from targeting search tools

### DIFF
--- a/meta_ads_mcp/core/targeting.py
+++ b/meta_ads_mcp/core/targeting.py
@@ -9,7 +9,7 @@ from .server import mcp_server
 
 @mcp_server.tool()
 @meta_api_tool
-async def search_interests(query: str, access_token: Optional[str] = None, limit: int = 25, account_id: Optional[str] = None) -> str:
+async def search_interests(query: str, access_token: Optional[str] = None, limit: int = 25) -> str:
     """
     Search for interest targeting options by keyword.
 
@@ -17,10 +17,6 @@ async def search_interests(query: str, access_token: Optional[str] = None, limit
         query: Search term for interests (e.g., "baseball", "cooking", "travel")
         access_token: Meta API access token (optional - will use cached token if not provided)
         limit: Maximum number of results to return (default: 25)
-        account_id: Meta Ads account ID (format: act_XXXXXXXXX). Required when using an
-                    account-restricted API token (i.e. tokens that are scoped to a specific
-                    ad account). If omitted, the Meta /search endpoint may return an error
-                    asking you to specify the account_id.
 
     Returns:
         JSON string containing interest data with id, name, audience_size, and path fields
@@ -34,8 +30,6 @@ async def search_interests(query: str, access_token: Optional[str] = None, limit
         "q": query,
         "limit": limit
     }
-    if account_id:
-        params["account_id"] = account_id
 
     data = await make_api_request(endpoint, access_token, params)
 
@@ -44,7 +38,7 @@ async def search_interests(query: str, access_token: Optional[str] = None, limit
 
 @mcp_server.tool()
 @meta_api_tool
-async def get_interest_suggestions(interest_list: List[str], access_token: Optional[str] = None, limit: int = 25, account_id: Optional[str] = None) -> str:
+async def get_interest_suggestions(interest_list: List[str], access_token: Optional[str] = None, limit: int = 25) -> str:
     """
     Get interest suggestions based on existing interests.
 
@@ -52,10 +46,6 @@ async def get_interest_suggestions(interest_list: List[str], access_token: Optio
         interest_list: List of interest names to get suggestions for (e.g., ["Basketball", "Soccer"])
         access_token: Meta API access token (optional - will use cached token if not provided)
         limit: Maximum number of suggestions to return (default: 25)
-        account_id: Meta Ads account ID (format: act_XXXXXXXXX). Required when using an
-                    account-restricted API token (i.e. tokens that are scoped to a specific
-                    ad account). If omitted, the Meta /search endpoint may return an error
-                    asking you to specify the account_id.
 
     Returns:
         JSON string containing suggested interests with id, name, audience_size, and description fields
@@ -69,8 +59,6 @@ async def get_interest_suggestions(interest_list: List[str], access_token: Optio
         "interest_list": json.dumps(interest_list),
         "limit": limit
     }
-    if account_id:
-        params["account_id"] = account_id
 
     data = await make_api_request(endpoint, access_token, params)
 
@@ -469,17 +457,13 @@ async def estimate_audience_size(
 
 @mcp_server.tool()
 @meta_api_tool
-async def search_behaviors(access_token: Optional[str] = None, limit: int = 50, account_id: Optional[str] = None) -> str:
+async def search_behaviors(access_token: Optional[str] = None, limit: int = 50) -> str:
     """
     Get all available behavior targeting options.
 
     Args:
         access_token: Meta API access token (optional - will use cached token if not provided)
         limit: Maximum number of results to return (default: 50)
-        account_id: Meta Ads account ID (format: act_XXXXXXXXX). Required when using an
-                    account-restricted API token (i.e. tokens that are scoped to a specific
-                    ad account). If omitted, the Meta /search endpoint may return an error
-                    asking you to specify the account_id.
 
     Returns:
         JSON string containing behavior targeting options with id, name, audience_size bounds, path, and description
@@ -490,8 +474,6 @@ async def search_behaviors(access_token: Optional[str] = None, limit: int = 50, 
         "class": "behaviors",
         "limit": limit
     }
-    if account_id:
-        params["account_id"] = account_id
 
     data = await make_api_request(endpoint, access_token, params)
 

--- a/tests/test_targeting.py
+++ b/tests/test_targeting.py
@@ -45,7 +45,7 @@ class TestSearchInterests:
 
             result = await search_interests(access_token="test_token", query="movies", limit=10)
 
-            # Verify API call (no account_id by default)
+            # Verify API call
             mock_api.assert_called_once_with(
                 "search",
                 "test_token",
@@ -61,36 +61,6 @@ class TestSearchInterests:
             assert result_data == mock_response
             assert len(result_data["data"]) == 2
             assert result_data["data"][0]["name"] == "Movies"
-
-    @pytest.mark.asyncio
-    async def test_search_interests_with_account_id(self):
-        """Test search_interests passes account_id when provided (for account-restricted tokens)"""
-        mock_response = {"data": [{"id": "123", "name": "Cooking"}]}
-
-        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
-            mock_api.return_value = mock_response
-
-            result = await search_interests(
-                access_token="test_token",
-                query="cooking",
-                limit=5,
-                account_id="act_123456789"
-            )
-
-            # Verify account_id is included in the API call
-            mock_api.assert_called_once_with(
-                "search",
-                "test_token",
-                {
-                    "type": "adinterest",
-                    "q": "cooking",
-                    "limit": 5,
-                    "account_id": "act_123456789"
-                }
-            )
-
-            result_data = json.loads(result)
-            assert result_data == mock_response
 
     @pytest.mark.asyncio
     async def test_search_interests_no_query(self):
@@ -120,7 +90,7 @@ class TestSearchInterests:
 
                 result = await search_interests(query="test")
 
-                # Verify default limit is used and no account_id
+                # Verify default limit is used
                 mock_api.assert_called_once_with(
                     "search",
                     "test_token",
@@ -170,7 +140,7 @@ class TestGetInterestSuggestions:
                 limit=15
             )
 
-            # Verify API call (no account_id by default)
+            # Verify API call
             mock_api.assert_called_once_with(
                 "search",
                 "test_token",
@@ -185,36 +155,6 @@ class TestGetInterestSuggestions:
             result_data = json.loads(result)
             assert result_data == mock_response
             assert len(result_data["data"]) == 2
-
-    @pytest.mark.asyncio
-    async def test_get_interest_suggestions_with_account_id(self):
-        """Test get_interest_suggestions passes account_id for account-restricted tokens"""
-        mock_response = {"data": [{"id": "999", "name": "Cricket"}]}
-
-        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
-            mock_api.return_value = mock_response
-
-            result = await get_interest_suggestions(
-                access_token="test_token",
-                interest_list=["Basketball"],
-                limit=10,
-                account_id="act_987654321"
-            )
-
-            # Verify account_id is included in the API call
-            mock_api.assert_called_once_with(
-                "search",
-                "test_token",
-                {
-                    "type": "adinterestsuggestion",
-                    "interest_list": '["Basketball"]',
-                    "limit": 10,
-                    "account_id": "act_987654321"
-                }
-            )
-
-            result_data = json.loads(result)
-            assert result_data == mock_response
 
     @pytest.mark.asyncio
     async def test_get_interest_suggestions_no_list(self):
@@ -350,7 +290,7 @@ class TestSearchBehaviors:
 
             result = await search_behaviors(access_token="test_token", limit=25)
 
-            # Verify API call (no account_id by default)
+            # Verify API call
             mock_api.assert_called_once_with(
                 "search",
                 "test_token",
@@ -362,35 +302,6 @@ class TestSearchBehaviors:
             )
 
             # Verify response
-            result_data = json.loads(result)
-            assert result_data == mock_response
-
-    @pytest.mark.asyncio
-    async def test_search_behaviors_with_account_id(self):
-        """Test search_behaviors passes account_id for account-restricted tokens"""
-        mock_response = {"data": [{"id": 111, "name": "Frequent Travelers"}]}
-
-        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
-            mock_api.return_value = mock_response
-
-            result = await search_behaviors(
-                access_token="test_token",
-                limit=10,
-                account_id="act_111222333"
-            )
-
-            # Verify account_id is included in the API call
-            mock_api.assert_called_once_with(
-                "search",
-                "test_token",
-                {
-                    "type": "adTargetingCategory",
-                    "class": "behaviors",
-                    "limit": 10,
-                    "account_id": "act_111222333"
-                }
-            )
-
             result_data = json.loads(result)
             assert result_data == mock_response
 


### PR DESCRIPTION
Reverts the account_id param additions from the previous PR. The error was coming from Pipeboard own ACL gate, not from Meta API. The correct fix is adding these tools to CROSS_ACCOUNT_TOOLS in route.ts (pipeboard.co PR).