### PR TITLE
Add pre-commit hook to block email addresses

### DIFF
--- a/.email-allowlist
+++ b/.email-allowlist
@@ -1,0 +1,11 @@
+# Allowed email addresses for the pre-commit check.
+# This repo is public — only add addresses here if they are
+# intentionally part of the project (e.g. package metadata, support contacts).
+#
+# One address per line. Lines starting with # are comments.
+
+# Package author (pyproject.toml)
+yves.junqueira@gmail.com
+
+# Pipeboard support contact (README, reports.py)
+info@pipeboard.co

--- a/scripts/check-no-emails.sh
+++ b/scripts/check-no-emails.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Pre-commit check: block commits that introduce email addresses.
+# This repo is public — keep email addresses out of the source tree.
+#
+# Existing emails are grandfathered via .email-allowlist (one pattern per line).
+# To add a new allowed email, append it to .email-allowlist.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+ALLOWLIST="$REPO_ROOT/.email-allowlist"
+
+EMAIL_RE='[A-Za-z0-9._%+=-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+
+# Build a grep -v filter from the allowlist (skip blank lines and comments)
+FILTER_ARGS=()
+if [ -f "$ALLOWLIST" ]; then
+    while IFS= read -r pattern || [ -n "$pattern" ]; do
+        # Skip comments and blank lines
+        [[ "$pattern" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${pattern// /}" ]] && continue
+        FILTER_ARGS+=(-e "$pattern")
+    done < "$ALLOWLIST"
+fi
+
+# Look at only added lines (starting with +) in the staged diff,
+# excluding the diff header lines (+++).
+matches=$(git diff --cached --diff-filter=ACMR -U0 -- . \
+    ':!.email-allowlist' \
+    | grep '^+' \
+    | grep -v '^+++' \
+    | grep -oE "$EMAIL_RE" \
+    || true)
+
+# Remove allowlisted addresses
+if [ ${#FILTER_ARGS[@]} -gt 0 ]; then
+    matches=$(echo "$matches" | grep -vF "${FILTER_ARGS[@]}" || true)
+fi
+
+# Drop empty lines
+matches=$(echo "$matches" | sed '/^$/d')
+
+if [ -n "$matches" ]; then
+    echo ""
+    echo "ERROR: Commit blocked — email address(es) found in staged changes:"
+    echo ""
+    echo "$matches" | sort -u | while read -r addr; do
+        echo "  $addr"
+    done
+    echo ""
+    echo "This is a public repository. Do not commit real email addresses."
+    echo "If this email is intentional, add it to .email-allowlist and retry."
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/check-no-emails.sh` that scans staged diffs for email patterns and blocks commits if any non-allowlisted address is found
- Adds `.email-allowlist` grandfathering the two existing emails (`yves.junqueira@gmail.com`, `info@pipeboard.co`)
- Protects this public repo from accidental email leaks

## Test plan
- [x] Verified: staging a file with a new email blocks the commit
- [x] Verified: allowlisted emails pass the check
- [x] Verified: clean staged changes pass the check