### PR TITLE
fix: video creatives with instagram_actor_id now include ad_formats to avoid error 1443048

### DIFF
--- a/.email-allowlist
+++ b/.email-allowlist
@@ -9,3 +9,7 @@ yves.junqueira@gmail.com
 
 # Pipeboard support contact (README, reports.py)
 info@pipeboard.co
+
+# pytest decorator false-positive: @pytest.mark.asyncio matches the email regex
+# because the diff +@pytest.mark.asyncio has + in the character class
+pytest.mark.asyncio

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1440,6 +1440,11 @@ async def create_ad_creative(
                      mode. In DOF mode, pass a single hash.
         video_id: Meta video ID for video creatives (cannot be used with image_hash or image_hashes).
                   Upload a video first via the Meta API, then use the returned video ID here.
+                  IMPORTANT: When also providing instagram_actor_id, both instagram_actor_id AND
+                  ad_formats=["SINGLE_VIDEO"] must be present — otherwise Meta returns error 1443048
+                  ("object_story_spec ill formed"). This is handled automatically: video creatives
+                  that include instagram_actor_id are routed through asset_feed_spec so that
+                  ad_formats=["SINGLE_VIDEO"] is always included in the API request.
         thumbnail_url: Thumbnail image URL for video creatives. Recommended when using video_id.
                       Meta will auto-generate a thumbnail if not provided.
         optimization_type: Optional. Valid values:
@@ -1464,6 +1469,11 @@ async def create_ad_creative(
                            to avoid JavaScript integer precision loss for IDs exceeding
                            Number.MAX_SAFE_INTEGER). Sent as instagram_user_id inside
                            object_story_spec (Meta deprecated instagram_actor_id in Jan 2026).
+                           IMPORTANT for video creatives: Meta requires ad_formats=["SINGLE_VIDEO"]
+                           in asset_feed_spec alongside instagram_user_id in object_story_spec —
+                           omitting either causes error 1443048 ("object_story_spec ill formed").
+                           This is auto-handled: video_id + instagram_actor_id always routes through
+                           asset_feed_spec so ad_formats=["SINGLE_VIDEO"] is included automatically.
         ad_formats: List of ad format strings for asset_feed_spec (e.g., ["AUTOMATIC_FORMAT"] for
                    Flexible ads, ["SINGLE_IMAGE"] for single image, ["SINGLE_VIDEO"] for video).
                    When optimization_type is "DEGREES_OF_FREEDOM" with image_hashes, defaults to
@@ -1798,9 +1808,14 @@ async def create_ad_creative(
         # - asset_customization_rules requires asset_feed_spec, OR
         # - video_id + description: Meta's video_data rejects "description" directly,
         #   so route through asset_feed_spec which supports descriptions for video ads
+        # - video_id + instagram_actor_id: Meta requires ad_formats=["SINGLE_VIDEO"] in
+        #   asset_feed_spec alongside instagram_user_id in object_story_spec — error 1443048
+        #   ("object_story_spec ill formed") occurs when asset_feed_spec is absent. Routing
+        #   through asset_feed_spec ensures ad_formats is automatically included.
         use_asset_feed = bool(
             headlines or descriptions or messages or image_hashes or videos or images
             or optimization_type or asset_customization_rules or (video_id and description)
+            or (video_id and instagram_actor_id)
         )
 
         # Track if this is a video creative

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -117,7 +117,13 @@ async def test_video_creative_with_thumbnail():
 
 @pytest.mark.asyncio
 async def test_video_creative_with_instagram_actor_id():
-    """Test that instagram_actor_id goes at the top level for video creatives (not inside video_data)."""
+    """Test that video_id + instagram_actor_id routes through asset_feed_spec.
+
+    Meta returns error 1443048 ("object_story_spec ill formed") when instagram_user_id is
+    in object_story_spec but ad_formats=["SINGLE_VIDEO"] is absent from asset_feed_spec.
+    The fix: video_id + instagram_actor_id always triggers asset_feed_spec so that
+    ad_formats=["SINGLE_VIDEO"] is automatically included in the API call.
+    """
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
          patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
@@ -144,11 +150,24 @@ async def test_video_creative_with_instagram_actor_id():
         )
 
         creative_data = mock_api.call_args_list[1][0][2]
-        video_data = creative_data["object_story_spec"]["video_data"]
 
-        # instagram_actor_id is sent as instagram_user_id inside object_story_spec
-        # (Meta deprecated instagram_actor_id in Jan 2026).
-        # It must NOT be inside video_data (error_subcode 1443050).
+        # Must use asset_feed_spec path (not simple video_data-only path) so that
+        # ad_formats=["SINGLE_VIDEO"] is present alongside instagram_user_id.
+        assert "asset_feed_spec" in creative_data, (
+            "video_id + instagram_actor_id must route through asset_feed_spec "
+            "to include ad_formats — otherwise Meta returns error 1443048"
+        )
+        afs = creative_data["asset_feed_spec"]
+        assert afs["ad_formats"] == ["SINGLE_VIDEO"], (
+            "ad_formats must be SINGLE_VIDEO for video creatives with instagram_actor_id"
+        )
+        assert "videos" in afs
+        assert afs["videos"][0]["video_id"] == "vid_333444"
+
+        # instagram_user_id must be in object_story_spec (not inside video_data)
+        # (Meta deprecated instagram_actor_id in Jan 2026; error_subcode 1443050 if inside video_data)
+        assert "object_story_spec" in creative_data
+        video_data = creative_data["object_story_spec"]["video_data"]
         assert "instagram_actor_id" not in video_data
         assert "instagram_user_id" not in video_data
         assert creative_data["object_story_spec"]["instagram_user_id"] == "ig_555666"
@@ -519,3 +538,94 @@ async def test_video_creative_description_only():
         afs = creative_data["asset_feed_spec"]
         assert afs["descriptions"] == [{"text": "Only description, no other plural params"}]
         assert "videos" in afs
+
+
+@pytest.mark.asyncio
+async def test_video_creative_instagram_actor_id_with_explicit_ad_formats():
+    """Test that explicitly passing ad_formats with instagram_actor_id + video_id also works.
+
+    The caller can still explicitly pass ad_formats=["SINGLE_VIDEO"]; it should be
+    respected (not overridden) when both instagram_actor_id and video_id are present.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch video thumbnail
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            # 2) POST create creative
+            {"id": "creative_vid_ig_fmt"},
+            # 3) GET creative details
+            {"id": "creative_vid_ig_fmt", "name": "Video IG Explicit Fmt", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_explicit_fmt",
+            name="Video IG Explicit Format",
+            link_url="https://example.com/",
+            instagram_actor_id="ig_777888",
+            ad_formats=["SINGLE_VIDEO"],
+            access_token="test_token"
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        # Must route through asset_feed_spec with explicit ad_formats respected
+        assert "asset_feed_spec" in creative_data
+        afs = creative_data["asset_feed_spec"]
+        assert afs["ad_formats"] == ["SINGLE_VIDEO"]
+        assert "videos" in afs
+        assert afs["videos"][0]["video_id"] == "vid_explicit_fmt"
+        assert creative_data["object_story_spec"]["instagram_user_id"] == "ig_777888"
+
+
+@pytest.mark.asyncio
+async def test_video_creative_without_instagram_actor_id_uses_simple_path():
+    """Regression: video_id without instagram_actor_id still uses simple object_story_spec path.
+
+    Only video_id + instagram_actor_id together triggers asset_feed_spec routing.
+    A plain video creative (no instagram_actor_id) should still use the simple path.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch video thumbnail
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            # 2) POST create creative
+            {"id": "creative_vid_simple"},
+            # 3) GET creative details
+            {"id": "creative_vid_simple", "name": "Simple Video", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_simple_only",
+            name="Simple Video No IG",
+            link_url="https://example.com/",
+            # No instagram_actor_id — should stay on simple path
+            access_token="test_token"
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        # Without instagram_actor_id, should use simple object_story_spec path (no asset_feed_spec)
+        assert "asset_feed_spec" not in creative_data
+        assert "object_story_spec" in creative_data
+        assert "video_data" in creative_data["object_story_spec"]
+        assert "instagram_user_id" not in creative_data["object_story_spec"]


### PR DESCRIPTION
## Summary

- **Root cause**: When `video_id` + `instagram_actor_id` were provided without other `asset_feed_spec` triggers, the code used the simple video path (only `object_story_spec` + `video_data`). This placed `instagram_user_id` in `object_story_spec` but never included `ad_formats=["SINGLE_VIDEO"]` in an `asset_feed_spec`. Meta requires both fields together, returning error 1443048 ("object_story_spec ill formed") when `asset_feed_spec` is absent.
- **Fix**: Extended the `use_asset_feed` condition to include `(video_id and instagram_actor_id)`. Video creatives with an Instagram actor ID now always route through `asset_feed_spec`, which automatically includes `ad_formats=["SINGLE_VIDEO"]`.
- **Docs**: Updated `video_id` and `instagram_actor_id` docstrings to document this behavior and the auto-handling.

## Test plan

- [ ] Existing `test_video_creative_with_instagram_actor_id` updated to verify `asset_feed_spec` is present with `ad_formats=["SINGLE_VIDEO"]`
- [ ] New test `test_video_creative_instagram_actor_id_with_explicit_ad_formats` verifies explicit caller-provided `ad_formats` is respected
- [ ] New test `test_video_creative_without_instagram_actor_id_uses_simple_path` confirms plain video creatives (no instagram_actor_id) still use the simple path unchanged
- [ ] All 421 existing tests pass