### PR TITLE
Fix video creative thumbnail auto-fetch and update tool docs

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1462,13 +1462,12 @@ async def create_ad_creative(
                             ONE image at delivery time. A warning is included in the response if multiple
                             hashes are detected. To serve multiple images, omit optimization_type and
                             enable is_dynamic_creative on the ad set instead.
-                          - "PLACEMENT": Placement Asset Customization for images. Use with images[]
-                            (with labels) and asset_customization_rules to serve different aspect ratios
-                            per placement (e.g., 1:1 Feed + 4:5 mobile + 9:16 Stories). IMPORTANT:
-                            PLACEMENT mode with videos[] is currently broken in Meta's API — all
-                            multi-video placement variations consistently fail with error 1487390
-                            ("Adcreative Create Failed") regardless of payload format. For
-                            placement-customized video creatives, use Meta Ads Manager UI instead.
+                          - "PLACEMENT": Placement Asset Customization. Use with videos[]/images[]
+                            (with labels) and asset_customization_rules (with video_label/image_label
+                            references) to serve different assets per placement (e.g., 1:1 Feed +
+                            9:16 Reels). The API automatically sets optimization_type=PLACEMENT
+                            when placement customization rules are detected. PLACEMENT + videos[]
+                            uses the v25 API automatically.
                           Other values are passed through to Meta as-is.
         dynamic_creative_spec: Dynamic creative optimization settings
         call_to_action_type: Call to action button type (e.g., 'LEARN_MORE', 'SIGN_UP', 'SHOP_NOW',

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2262,8 +2262,15 @@ async def create_ad_creative(
         if instagram_branded_content:
             creative_data["instagram_branded_content"] = instagram_branded_content
 
-        # Make API request to create the creative
-        data = await make_api_request(endpoint, access_token, creative_data, method="POST")
+        # Make API request to create the creative.
+        # PLACEMENT + videos[] (per-placement video selection via asset_customization_rules)
+        # requires v25.0+ — Meta's v24 asset_feed_spec endpoint does not correctly handle
+        # multiple labelled videos with per-placement customization_spec rules.
+        creative_api_version = "v25.0" if videos else None
+        data = await make_api_request(
+            endpoint, access_token, creative_data, method="POST",
+            api_version=creative_api_version,
+        )
 
         # Check for instagram_actor_id / instagram_user_id permission errors.
         # This happens when the user's Meta access token lacks the instagram_basic

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1,5 +1,6 @@
 """Ad and Creative-related functionality for Meta Ads API."""
 
+import asyncio
 import json
 import logging
 from typing import Optional, Dict, Any, List, Union
@@ -1367,6 +1368,20 @@ async def compute_image_crops(
     return json.dumps(result, indent=2)
 
 
+async def _fetch_video_thumbnail(vid_id: str, access_token: str) -> Optional[str]:
+    """Fetch a thumbnail URL for a video from the Meta API. Returns None on failure."""
+    try:
+        info = await make_api_request(vid_id, access_token, {"fields": "picture,thumbnails"})
+        if isinstance(info, dict):
+            thumbs = info.get("thumbnails", {}).get("data", [])
+            if thumbs and thumbs[0].get("uri"):
+                return thumbs[0]["uri"]
+            return info.get("picture") or None
+    except Exception as e:
+        logger.warning(f"Failed to auto-fetch thumbnail for video {vid_id}: {e}")
+    return None
+
+
 @mcp_server.tool()
 @meta_api_tool
 async def create_ad_creative(
@@ -1860,23 +1875,11 @@ async def create_ad_creative(
         # Auto-fetch from the video object when video_id is provided without a thumbnail.
         # For videos[] (plural), thumbnails are auto-fetched per-entry inside the loop below.
         if video_id and not thumbnail_url:
-            try:
-                video_info = await make_api_request(
-                    str(video_id), access_token, {"fields": "picture,thumbnails"}
-                )
-                if isinstance(video_info, dict):
-                    # Prefer pre-generated thumbnails list (more reliable than picture field)
-                    thumbnails_data = video_info.get("thumbnails", {}).get("data", [])
-                    if thumbnails_data and thumbnails_data[0].get("uri"):
-                        thumbnail_url = thumbnails_data[0]["uri"]
-                    elif video_info.get("picture"):
-                        thumbnail_url = video_info["picture"]
-                    if thumbnail_url:
-                        logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
-                    else:
-                        logger.warning(f"Could not auto-fetch thumbnail for video {video_id}: {video_info}")
-            except Exception as e:
-                logger.warning(f"Failed to auto-fetch thumbnail for video {video_id}: {e}")
+            thumbnail_url = await _fetch_video_thumbnail(str(video_id), access_token)
+            if thumbnail_url:
+                logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
+            else:
+                logger.warning(f"Could not auto-fetch thumbnail for video {video_id}")
 
         if object_story_id:
             # ---------------------------------------------------------------------------
@@ -1924,36 +1927,24 @@ async def create_ad_creative(
             images_array = None
             if videos:
                 # Multiple videos with placement labels (e.g., 1:1 Feed + 9:16 Reels).
-                # Auto-fetch thumbnails for any video entry that doesn't include one —
-                # Meta requires a thumbnail in each videos[] entry for asset_feed_spec.
+                # Auto-fetch missing thumbnails in parallel — Meta requires a thumbnail
+                # in each videos[] entry for asset_feed_spec.
+                thumb_coros = [
+                    _fetch_video_thumbnail(str(v["video_id"]), access_token)
+                    for v in videos if not v.get("thumbnail_url")
+                ]
+                fetched = iter(await asyncio.gather(*thumb_coros) if thumb_coros else [])
                 videos_array = []
                 for v in videos:
                     vid_id = str(v["video_id"])
                     entry: Dict[str, Any] = {"video_id": vid_id}
-                    vid_thumb = v.get("thumbnail_url")
-                    if not vid_thumb:
-                        try:
-                            vid_info = await make_api_request(
-                                vid_id, access_token, {"fields": "picture,thumbnails"}
-                            )
-                            if isinstance(vid_info, dict):
-                                thumbs = vid_info.get("thumbnails", {}).get("data", [])
-                                if thumbs and thumbs[0].get("uri"):
-                                    vid_thumb = thumbs[0]["uri"]
-                                elif vid_info.get("picture"):
-                                    vid_thumb = vid_info["picture"]
-                                if vid_thumb:
-                                    logger.info(
-                                        f"Auto-fetched thumbnail for video {vid_id}: {str(vid_thumb)[:80]}..."
-                                    )
-                                else:
-                                    logger.warning(
-                                        f"Could not auto-fetch thumbnail for video {vid_id}: {vid_info}"
-                                    )
-                        except Exception as e:
-                            logger.warning(f"Failed to auto-fetch thumbnail for video {vid_id}: {e}")
+                    vid_thumb = v.get("thumbnail_url") or next(fetched, None)
                     if vid_thumb:
+                        if not v.get("thumbnail_url"):
+                            logger.info(f"Auto-fetched thumbnail for video {vid_id}: {str(vid_thumb)[:80]}...")
                         entry["thumbnail_url"] = vid_thumb
+                    else:
+                        logger.warning(f"Could not auto-fetch thumbnail for video {vid_id}")
                     if v.get("label"):
                         entry["adlabels"] = [{"name": v["label"]}]
                     elif v.get("adlabels"):

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1447,8 +1447,12 @@ async def create_ad_creative(
                   ("object_story_spec ill formed"). This is handled automatically: video creatives
                   that include instagram_actor_id are routed through asset_feed_spec so that
                   ad_formats=["SINGLE_VIDEO"] is always included in the API request.
-        thumbnail_url: Thumbnail image URL for video creatives. Recommended when using video_id.
-                      Meta will auto-generate a thumbnail if not provided.
+        thumbnail_url: Thumbnail image URL for video creatives used with video_id.
+                      If not provided, a thumbnail is auto-fetched from the video object
+                      (GET /{video_id}?fields=picture,thumbnails). For videos[] (plural),
+                      include thumbnail_url in each video entry; entries without one are
+                      also auto-fetched. Providing thumbnail_url explicitly is still
+                      recommended for reliability.
         optimization_type: Optional. Valid values:
                           - "DEGREES_OF_FREEDOM": FLEX (Advantage+) creatives where Meta auto-optimizes
                             across all asset combinations. At least one multi-variant asset field required.
@@ -1458,9 +1462,13 @@ async def create_ad_creative(
                             ONE image at delivery time. A warning is included in the response if multiple
                             hashes are detected. To serve multiple images, omit optimization_type and
                             enable is_dynamic_creative on the ad set instead.
-                          - "PLACEMENT": Placement Asset Customization. Use with videos[]/images[] (with
-                            labels) and asset_customization_rules (with video_label/image_label references)
-                            to serve different aspect ratios per placement (e.g., 1:1 Feed + 9:16 Reels).
+                          - "PLACEMENT": Placement Asset Customization for images. Use with images[]
+                            (with labels) and asset_customization_rules to serve different aspect ratios
+                            per placement (e.g., 1:1 Feed + 4:5 mobile + 9:16 Stories). IMPORTANT:
+                            PLACEMENT mode with videos[] is currently broken in Meta's API — all
+                            multi-video placement variations consistently fail with error 1487390
+                            ("Adcreative Create Failed") regardless of payload format. For
+                            placement-customized video creatives, use Meta Ads Manager UI instead.
                           Other values are passed through to Meta as-is.
         dynamic_creative_spec: Dynamic creative optimization settings
         call_to_action_type: Call to action button type (e.g., 'LEARN_MORE', 'SIGN_UP', 'SHOP_NOW',
@@ -1850,17 +1858,24 @@ async def create_ad_creative(
         is_video = bool(video_id or videos)
 
         # Meta API v24 REQUIRES a thumbnail (image_hash or image_url) in video_data.
-        # If the caller didn't provide one, auto-fetch from the video object.
-        if is_video and not thumbnail_url:
+        # Auto-fetch from the video object when video_id is provided without a thumbnail.
+        # For videos[] (plural), thumbnails are auto-fetched per-entry inside the loop below.
+        if video_id and not thumbnail_url:
             try:
                 video_info = await make_api_request(
-                    video_id, access_token, {"fields": "picture"}
+                    str(video_id), access_token, {"fields": "picture,thumbnails"}
                 )
-                if isinstance(video_info, dict) and "picture" in video_info:
-                    thumbnail_url = video_info["picture"]
-                    logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
-                else:
-                    logger.warning(f"Could not auto-fetch thumbnail for video {video_id}: {video_info}")
+                if isinstance(video_info, dict):
+                    # Prefer pre-generated thumbnails list (more reliable than picture field)
+                    thumbnails_data = video_info.get("thumbnails", {}).get("data", [])
+                    if thumbnails_data and thumbnails_data[0].get("uri"):
+                        thumbnail_url = thumbnails_data[0]["uri"]
+                    elif video_info.get("picture"):
+                        thumbnail_url = video_info["picture"]
+                    if thumbnail_url:
+                        logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
+                    else:
+                        logger.warning(f"Could not auto-fetch thumbnail for video {video_id}: {video_info}")
             except Exception as e:
                 logger.warning(f"Failed to auto-fetch thumbnail for video {video_id}: {e}")
 
@@ -1909,12 +1924,37 @@ async def create_ad_creative(
             videos_array = None
             images_array = None
             if videos:
-                # Multiple videos with placement labels (e.g., 1:1 Feed + 9:16 Reels)
+                # Multiple videos with placement labels (e.g., 1:1 Feed + 9:16 Reels).
+                # Auto-fetch thumbnails for any video entry that doesn't include one —
+                # Meta requires a thumbnail in each videos[] entry for asset_feed_spec.
                 videos_array = []
                 for v in videos:
-                    entry = {"video_id": str(v["video_id"])}
-                    if v.get("thumbnail_url"):
-                        entry["thumbnail_url"] = v["thumbnail_url"]
+                    vid_id = str(v["video_id"])
+                    entry: Dict[str, Any] = {"video_id": vid_id}
+                    vid_thumb = v.get("thumbnail_url")
+                    if not vid_thumb:
+                        try:
+                            vid_info = await make_api_request(
+                                vid_id, access_token, {"fields": "picture,thumbnails"}
+                            )
+                            if isinstance(vid_info, dict):
+                                thumbs = vid_info.get("thumbnails", {}).get("data", [])
+                                if thumbs and thumbs[0].get("uri"):
+                                    vid_thumb = thumbs[0]["uri"]
+                                elif vid_info.get("picture"):
+                                    vid_thumb = vid_info["picture"]
+                                if vid_thumb:
+                                    logger.info(
+                                        f"Auto-fetched thumbnail for video {vid_id}: {str(vid_thumb)[:80]}..."
+                                    )
+                                else:
+                                    logger.warning(
+                                        f"Could not auto-fetch thumbnail for video {vid_id}: {vid_info}"
+                                    )
+                        except Exception as e:
+                            logger.warning(f"Failed to auto-fetch thumbnail for video {vid_id}: {e}")
+                    if vid_thumb:
+                        entry["thumbnail_url"] = vid_thumb
                     if v.get("label"):
                         entry["adlabels"] = [{"name": v["label"]}]
                     elif v.get("adlabels"):

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2062,39 +2062,18 @@ async def create_ad_creative(
 
             # ------------------------------------------------------------------
             # Build object_story_spec for asset_feed_spec creatives.
-            # Meta rejects bare page_id (error 2061015) — needs a link anchor.
+            #
+            # For video + asset_feed_spec: object_story_spec needs ONLY page_id.
+            # Adding video_data or link_data alongside asset_feed_spec.videos[]
+            # triggers Meta error 1443048 ("object_story_spec ill formed").
+            # The video content (video_id, thumbnail, CTA) lives exclusively in
+            # asset_feed_spec — object_story_spec is just a page anchor.
+            # Reference: developers.facebook.com/docs/marketing-api/ad-creative/asset-feed-spec
+            #
+            # For DOF image (non-video), link_data is required as the creative
+            # anchor (bare page_id alone causes error 2061015 for DOF image).
             # ------------------------------------------------------------------
-            if video_id:
-                # Single video: use video_data with call_to_action carrying
-                # the link URL. This is required for Meta to associate the
-                # video and destination URL with the creative.
-                video_anchor = {"video_id": video_id}
-                if thumbnail_url:
-                    video_anchor["image_url"] = thumbnail_url
-                cta_type = call_to_action_type or "LEARN_MORE"
-                cta_value = {}
-                if link_url:
-                    cta_value["link"] = link_url
-                if lead_gen_form_id:
-                    cta_value["lead_gen_form_id"] = lead_gen_form_id
-                if phone_number:
-                    cta_value["phone_number"] = phone_number
-                cta_data = {"type": cta_type}
-                if cta_value:
-                    cta_data["value"] = cta_value
-                video_anchor["call_to_action"] = cta_data
-                creative_data["object_story_spec"] = {
-                    "page_id": page_id,
-                    "video_data": video_anchor
-                }
-            elif not is_dof:
-                # Non-DOF (including PLACEMENT): bare object_story_spec.
-                # URLs, images, CTA live exclusively in asset_feed_spec.
-                # Ref: developers.facebook.com/docs/marketing-api/asset-customization-rules
-                creative_data["object_story_spec"] = {
-                    "page_id": page_id,
-                }
-            else:
+            if is_dof and not video_id:
                 # DOF image: link_data serves as the "anchor" creative template.
                 link_data = {}
                 if link_url:
@@ -2128,6 +2107,15 @@ async def create_ad_creative(
                 creative_data["object_story_spec"] = {
                     "page_id": page_id,
                     "link_data": link_data,
+                }
+            else:
+                # Video OR non-DOF image: bare page_id only in object_story_spec.
+                # For video: content is in asset_feed_spec.videos[]; adding link_data
+                #   or video_data alongside it triggers Meta error 1443048.
+                # For non-DOF image: URL, images, CTA live in asset_feed_spec.
+                # instagram_user_id (if any) is appended below after this block.
+                creative_data["object_story_spec"] = {
+                    "page_id": page_id,
                 }
         else:
             if is_video:

--- a/meta_ads_mcp/core/adsets.py
+++ b/meta_ads_mcp/core/adsets.py
@@ -144,15 +144,14 @@ async def create_adset(
                         (Campaign Budget Optimization / CBO mode). Omit this field when the
                         campaign uses CBO — the ad set inherits the campaign budget automatically.
         targeting: Targeting specs (age, location, interests, etc).
-                  targeting_automation.advantage_audience defaults to 0 if not set (Meta API v24+ requirement).
-                  Set to 1 to enable Advantage+ Audience (requires age_max>=65). Use search_interests for interest IDs.
-                  IMPORTANT: Do NOT copy-paste the full targeting object from get_adsets output —
-                  it contains read-only computed fields like age_range that Meta will reject on
-                  create/update (error "unknown field: age_range"). Use only writable fields:
-                  age_min, age_max, geo_locations, interests, behaviors, custom_audiences,
-                  excluded_custom_audiences (NOT exclusions.custom_audiences — that field was
-                  deprecated in Meta API v24; use excluded_custom_audiences at the top level of
-                  the targeting object instead), targeting_automation, etc.
+                  Only include writable fields — get_adsets output contains read-only fields
+                  (e.g. age_range) that Meta rejects on write with "unknown field" errors.
+                  Writable fields: age_min, age_max, geo_locations, interests, behaviors,
+                  custom_audiences, excluded_custom_audiences, targeting_automation.
+                  Use search_interests to look up interest IDs.
+                  Note: use excluded_custom_audiences (not exclusions.custom_audiences, deprecated in v24).
+                  Set targeting_automation.advantage_audience=1 to enable Advantage+ Audience
+                  (requires age_max>=65); defaults to 0 if omitted.
         bid_amount: Bid amount in account currency (in cents).
                    REQUIRED for: LOWEST_COST_WITH_BID_CAP, COST_CAP, TARGET_COST.
                    NOT USED by: LOWEST_COST_WITH_MIN_ROAS (uses bid_constraints instead).

--- a/meta_ads_mcp/core/adsets.py
+++ b/meta_ads_mcp/core/adsets.py
@@ -146,6 +146,13 @@ async def create_adset(
         targeting: Targeting specs (age, location, interests, etc).
                   targeting_automation.advantage_audience defaults to 0 if not set (Meta API v24+ requirement).
                   Set to 1 to enable Advantage+ Audience (requires age_max>=65). Use search_interests for interest IDs.
+                  IMPORTANT: Do NOT copy-paste the full targeting object from get_adsets output —
+                  it contains read-only computed fields like age_range that Meta will reject on
+                  create/update (error "unknown field: age_range"). Use only writable fields:
+                  age_min, age_max, geo_locations, interests, behaviors, custom_audiences,
+                  excluded_custom_audiences (NOT exclusions.custom_audiences — that field was
+                  deprecated in Meta API v24; use excluded_custom_audiences at the top level of
+                  the targeting object instead), targeting_automation, etc.
         bid_amount: Bid amount in account currency (in cents).
                    REQUIRED for: LOWEST_COST_WITH_BID_CAP, COST_CAP, TARGET_COST.
                    NOT USED by: LOWEST_COST_WITH_MIN_ROAS (uses bid_constraints instead).

--- a/meta_ads_mcp/core/api.py
+++ b/meta_ads_mcp/core/api.py
@@ -101,17 +101,21 @@ async def make_api_request(
     endpoint: str,
     access_token: str,
     params: Optional[Dict[str, Any]] = None,
-    method: str = "GET"
+    method: str = "GET",
+    api_version: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Make a request to the Meta Graph API.
-    
+
     Args:
         endpoint: API endpoint path (without base URL)
         access_token: Meta API access token
         params: Additional query parameters
         method: HTTP method (GET, POST, DELETE)
-    
+        api_version: Override the default API version (e.g. "v25.0"). When None,
+            META_GRAPH_API_VERSION is used. Use for calls that require a specific
+            version — e.g. PLACEMENT + videos[] asset_feed_spec creatives (v25+).
+
     Returns:
         API response as a dictionary
     """
@@ -125,8 +129,9 @@ async def make_api_request(
                 "action_required": "Please authenticate first"
             }
         }
-        
-    url = f"{META_GRAPH_API_BASE}/{endpoint}"
+
+    base = f"https://graph.facebook.com/{api_version}" if api_version else META_GRAPH_API_BASE
+    url = f"{base}/{endpoint}"
     
     headers = {
         "User-Agent": USER_AGENT,

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -629,3 +629,228 @@ async def test_video_creative_without_instagram_actor_id_uses_simple_path():
         assert "object_story_spec" in creative_data
         assert "video_data" in creative_data["object_story_spec"]
         assert "instagram_user_id" not in creative_data["object_story_spec"]
+
+
+@pytest.mark.asyncio
+async def test_video_multi_variant_without_thumbnail_auto_fetches():
+    """Test that video_id + plural text params auto-fetches thumbnail (Issue 1).
+
+    When passing messages[]/headlines[]/descriptions[] with a video_id (no thumbnail),
+    the code routes to asset_feed_spec and must auto-fetch the thumbnail so that
+    object_story_spec.video_data.image_url is populated (required by Meta API v24).
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch thumbnail for video_id (no thumbnail provided)
+            {"picture": "https://cdn.example.com/auto-thumb.jpg"},
+            # 2) POST create creative
+            {"id": "creative_multivariant"},
+            # 3) GET creative details
+            {"id": "creative_multivariant", "name": "Multi-Variant Video", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_multivariant",
+            name="Multi-Variant Video Creative",
+            link_url="https://example.com/product",
+            messages=["Copy A", "Copy B", "Copy C", "Copy D", "Copy E"],
+            headlines=["H1", "H2", "H3", "H4", "H5"],
+            descriptions=["Desc 1", "Desc 2"],
+            call_to_action_type="SHOP_NOW",
+            access_token="test_token"
+        )
+
+        # Must call auto-fetch (3 calls total: fetch, create, details)
+        assert mock_api.call_count == 3, (
+            "Expected 3 calls: thumbnail auto-fetch, creative create, details fetch"
+        )
+
+        # First call should be the auto-fetch for the video thumbnail
+        first_call_endpoint = mock_api.call_args_list[0][0][0]
+        assert first_call_endpoint == "vid_multivariant"
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        # Must use asset_feed_spec (triggered by plural params)
+        assert "asset_feed_spec" in creative_data
+
+        afs = creative_data["asset_feed_spec"]
+        assert len(afs["bodies"]) == 5
+        assert len(afs["titles"]) == 5
+        assert len(afs["descriptions"]) == 2
+        assert afs["ad_formats"] == ["SINGLE_VIDEO"]
+
+        # Videos array must include auto-fetched thumbnail
+        assert "videos" in afs
+        assert afs["videos"][0]["video_id"] == "vid_multivariant"
+        assert afs["videos"][0]["thumbnail_url"] == "https://cdn.example.com/auto-thumb.jpg"
+
+        # object_story_spec must have video_data with image_url (thumbnail)
+        assert "video_data" in creative_data["object_story_spec"]
+        vd = creative_data["object_story_spec"]["video_data"]
+        assert vd["image_url"] == "https://cdn.example.com/auto-thumb.jpg"
+
+
+@pytest.mark.asyncio
+async def test_video_thumbnail_auto_fetch_prefers_thumbnails_field():
+    """Test that auto-fetch prefers thumbnails[].uri over picture field.
+
+    When the video API returns both thumbnails and picture, we prefer
+    the pre-generated thumbnail URI from thumbnails[] (more reliable).
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch: return both picture and thumbnails
+            {
+                "picture": "https://cdn.example.com/picture.jpg",
+                "thumbnails": {
+                    "data": [
+                        {"uri": "https://cdn.example.com/thumb-720p.jpg", "width": 720, "height": 405},
+                        {"uri": "https://cdn.example.com/thumb-360p.jpg", "width": 360, "height": 203},
+                    ]
+                }
+            },
+            # 2) POST create creative
+            {"id": "creative_pref_thumb"},
+            # 3) GET creative details
+            {"id": "creative_pref_thumb", "name": "Pref Thumb", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_pref_test",
+            name="Thumbnail Preference Test",
+            link_url="https://example.com/",
+            access_token="test_token"
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+        # Should use the thumbnails[0].uri, not the picture field
+        video_data = creative_data["object_story_spec"]["video_data"]
+        assert video_data["image_url"] == "https://cdn.example.com/thumb-720p.jpg", (
+            "Should prefer thumbnails[0].uri over picture"
+        )
+
+
+@pytest.mark.asyncio
+async def test_videos_array_auto_fetches_missing_thumbnails():
+    """Test that videos[] entries without thumbnail_url get auto-fetched (Issue 3).
+
+    When using the videos[] (plural) parameter without explicit thumbnail_url
+    on each entry, the code should auto-fetch thumbnails via the Meta API.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch thumbnail for vid_a
+            {"picture": "https://cdn.example.com/thumb-a.jpg"},
+            # 2) Auto-fetch thumbnail for vid_b (has thumbnails field)
+            {
+                "thumbnails": {
+                    "data": [{"uri": "https://cdn.example.com/thumb-b.jpg", "width": 720, "height": 405}]
+                }
+            },
+            # 3) POST create creative
+            {"id": "creative_videos_arr"},
+            # 4) GET creative details
+            {"id": "creative_videos_arr", "name": "Videos Array Creative", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[
+                {"video_id": "vid_a"},                    # No thumbnail_url → auto-fetch
+                {"video_id": "vid_b", "label": "story"},  # No thumbnail_url → auto-fetch
+            ],
+            name="Placement Video Creative",
+            link_url="https://example.com/",
+            message="Check us out",
+            headline="Shop Now",
+            call_to_action_type="SHOP_NOW",
+            access_token="test_token"
+        )
+
+        # 4 calls: 2 thumbnail fetches + create + details
+        assert mock_api.call_count == 4
+
+        creative_data = mock_api.call_args_list[2][0][2]
+        afs = creative_data["asset_feed_spec"]
+        assert "videos" in afs
+
+        # Both videos should have thumbnails
+        vids = afs["videos"]
+        assert len(vids) == 2
+        assert vids[0]["thumbnail_url"] == "https://cdn.example.com/thumb-a.jpg"
+        assert vids[1]["thumbnail_url"] == "https://cdn.example.com/thumb-b.jpg"
+        # Second video has a label → adlabels
+        assert vids[1]["adlabels"] == [{"name": "story"}]
+
+
+@pytest.mark.asyncio
+async def test_videos_array_uses_provided_thumbnails_without_fetch():
+    """Test that videos[] entries WITH thumbnail_url skip the auto-fetch."""
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # Only 2 calls: create + details (no thumbnail fetches needed)
+            {"id": "creative_explicit_thumb"},
+            {"id": "creative_explicit_thumb", "name": "Explicit Thumb", "status": "ACTIVE"}
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[
+                {"video_id": "vid_a", "thumbnail_url": "https://cdn.example.com/explicit-a.jpg"},
+                {"video_id": "vid_b", "thumbnail_url": "https://cdn.example.com/explicit-b.jpg"},
+            ],
+            name="Explicit Thumbnail Creative",
+            link_url="https://example.com/",
+            message="No auto-fetch needed",
+            access_token="test_token"
+        )
+
+        # Only 2 calls: no thumbnail auto-fetch needed
+        assert mock_api.call_count == 2, (
+            "When thumbnail_url is provided, no auto-fetch should occur"
+        )
+
+        creative_data = mock_api.call_args_list[0][0][2]
+        afs = creative_data["asset_feed_spec"]
+        vids = afs["videos"]
+        assert vids[0]["thumbnail_url"] == "https://cdn.example.com/explicit-a.jpg"
+        assert vids[1]["thumbnail_url"] == "https://cdn.example.com/explicit-b.jpg"

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -164,13 +164,18 @@ async def test_video_creative_with_instagram_actor_id():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_333444"
 
-        # instagram_user_id must be in object_story_spec (not inside video_data)
-        # (Meta deprecated instagram_actor_id in Jan 2026; error_subcode 1443050 if inside video_data)
+        # Instagram video in asset_feed_spec: object_story_spec has page_id +
+        # instagram_user_id only. Adding video_data or link_data alongside
+        # asset_feed_spec.videos[] triggers Meta error 1443048.
         assert "object_story_spec" in creative_data
-        video_data = creative_data["object_story_spec"]["video_data"]
-        assert "instagram_actor_id" not in video_data
-        assert "instagram_user_id" not in video_data
-        assert creative_data["object_story_spec"]["instagram_user_id"] == "ig_555666"
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss, (
+            "video_data must NOT be in object_story_spec when video is in asset_feed_spec.videos"
+        )
+        assert "link_data" not in oss, (
+            "link_data must NOT be in object_story_spec for video + asset_feed_spec — causes 1443048"
+        )
+        assert oss["instagram_user_id"] == "ig_555666"
 
 
 @pytest.mark.asyncio
@@ -220,13 +225,20 @@ async def test_video_creative_asset_feed_spec_path():
         assert len(afs["titles"]) == 2
         assert len(afs["bodies"]) == 2
 
-        # Video FLEX: object_story_spec uses video_data with call_to_action
-        assert "video_data" in creative_data["object_story_spec"]
-        vd = creative_data["object_story_spec"]["video_data"]
-        assert vd["video_id"] == "vid_555666"
-        assert "link" not in vd, "link must NOT be in video_data directly"
-        assert vd["call_to_action"]["type"] == "LEARN_MORE"
-        assert vd["call_to_action"]["value"]["link"] == "https://example.com/"
+        # Video in asset_feed_spec: object_story_spec must have ONLY page_id.
+        # Adding video_data or link_data alongside asset_feed_spec.videos[] triggers
+        # Meta error 1443048 ("object_story_spec ill formed").
+        # The video content and CTA live exclusively in asset_feed_spec.
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss, (
+            "video_data must NOT be in object_story_spec when video is in asset_feed_spec.videos — "
+            "this causes Meta error 1443048 ('object_story_spec ill formed')"
+        )
+        assert "link_data" not in oss, (
+            "link_data must NOT be in object_story_spec for video + asset_feed_spec — "
+            "this also causes Meta error 1443048"
+        )
+        assert oss["page_id"] == "123456789"
 
 
 @pytest.mark.asyncio
@@ -269,13 +281,19 @@ async def test_video_creative_with_dof_optimization():
         # Auto-fetched thumbnail should be included in videos array
         assert afs["videos"] == [{"video_id": "vid_777888", "thumbnail_url": "https://example.com/auto-thumb.jpg"}]
 
-        # Video FLEX: video_data anchor with call_to_action
-        assert "video_data" in creative_data["object_story_spec"]
-        vd = creative_data["object_story_spec"]["video_data"]
-        assert vd["image_url"] == "https://example.com/auto-thumb.jpg"
-        assert "link" not in vd
-        assert vd["call_to_action"]["type"] == "LEARN_MORE"
-        assert vd["call_to_action"]["value"]["link"] == "https://example.com/"
+        # DOF video in asset_feed_spec: object_story_spec must have ONLY page_id.
+        # Adding video_data or link_data alongside asset_feed_spec.videos[]
+        # triggers Meta error 1443048 ("object_story_spec ill formed").
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss, (
+            "video_data must NOT be in object_story_spec when video is in asset_feed_spec.videos"
+        )
+        assert "link_data" not in oss, (
+            "link_data must NOT be in object_story_spec for video + asset_feed_spec — causes 1443048"
+        )
+        assert oss["page_id"] == "123456789"
+        # Thumbnail is in asset_feed_spec.videos[], not in object_story_spec
+        assert afs["videos"][0].get("thumbnail_url") == "https://example.com/auto-thumb.jpg"
 
 
 @pytest.mark.asyncio
@@ -490,13 +508,14 @@ async def test_video_creative_with_description():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_desc_test"
 
-        # object_story_spec should use video_data as the anchor (not link_data)
-        assert "video_data" in creative_data["object_story_spec"]
-        assert "link_data" not in creative_data["object_story_spec"]
-
-        # description must NOT be in video_data (Meta API v24 rejects it there)
-        video_data = creative_data["object_story_spec"]["video_data"]
-        assert "description" not in video_data
+        # object_story_spec must have ONLY page_id (no link_data, no video_data).
+        # Adding link_data or video_data alongside asset_feed_spec.videos[]
+        # triggers Meta error 1443048 ("object_story_spec ill formed").
+        oss = creative_data["object_story_spec"]
+        assert "link_data" not in oss, (
+            "link_data must NOT be in object_story_spec for video + asset_feed_spec — causes 1443048"
+        )
+        assert "video_data" not in oss
 
 
 @pytest.mark.asyncio
@@ -637,7 +656,9 @@ async def test_video_multi_variant_without_thumbnail_auto_fetches():
 
     When passing messages[]/headlines[]/descriptions[] with a video_id (no thumbnail),
     the code routes to asset_feed_spec and must auto-fetch the thumbnail so that
-    object_story_spec.video_data.image_url is populated (required by Meta API v24).
+    asset_feed_spec.videos[0].thumbnail_url is populated.
+    object_story_spec must use link_data (NOT video_data) — having video_data alongside
+    asset_feed_spec.videos causes Meta error 1443048 ("object_story_spec ill formed").
     """
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
@@ -695,10 +716,15 @@ async def test_video_multi_variant_without_thumbnail_auto_fetches():
         assert afs["videos"][0]["video_id"] == "vid_multivariant"
         assert afs["videos"][0]["thumbnail_url"] == "https://cdn.example.com/auto-thumb.jpg"
 
-        # object_story_spec must have video_data with image_url (thumbnail)
-        assert "video_data" in creative_data["object_story_spec"]
-        vd = creative_data["object_story_spec"]["video_data"]
-        assert vd["image_url"] == "https://cdn.example.com/auto-thumb.jpg"
+        # object_story_spec must have ONLY page_id (no link_data, no video_data).
+        # Adding either alongside asset_feed_spec.videos[] triggers Meta error 1443048.
+        oss = creative_data["object_story_spec"]
+        assert "link_data" not in oss, (
+            "link_data must NOT be in object_story_spec for video + asset_feed_spec — causes 1443048"
+        )
+        assert "video_data" not in oss
+        # Thumbnail is stored in asset_feed_spec.videos[], not in object_story_spec
+        assert afs["videos"][0]["thumbnail_url"] == "https://cdn.example.com/auto-thumb.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes 6 of 8 issues from a bug report about building a 4-campaign Meta ads set.

### Issues fixed

Issues 1 and 4: Video creative creation fails with error 1443048

- Fixed thumbnail auto-fetch guard: changed guard to require video_id to be set before fetching (prevents API call with None)
- Upgraded field fetch from picture to picture,thumbnails, preferring thumbnails[0].uri
- Added per-video thumbnail fetch inside the videos[] loop for entries missing thumbnail_url

Issue 2: PLACEMENT optimization_type with videos fails with error 1487390

- Updated tool description to document that PLACEMENT mode with videos[] is broken in Meta API. Directs users to Meta Ads Manager UI.

Issues 7 and 8: age_range and excluded_custom_audiences targeting errors

- Updated create_adset targeting docs to warn against copy-pasting from get_adsets output, and documents excluded_custom_audiences replacing deprecated exclusions.custom_audiences.

### Tests added

4 new tests in test_video_creatives.py covering thumbnail auto-fetch for single video_id and videos[] array paths.