### PR TITLE
fix(ads): skip video thumbnail auto-fetch when only videos[] is passed

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1851,7 +1851,11 @@ async def create_ad_creative(
 
         # Meta API v24 REQUIRES a thumbnail (image_hash or image_url) in video_data.
         # If the caller didn't provide one, auto-fetch from the video object.
-        if is_video and not thumbnail_url:
+        # Guard on `video_id` (not `is_video`): when only `videos=[...]` is passed,
+        # `video_id` is None and calling Meta with a None ID returns a generic error
+        # ("Could not auto-fetch thumbnail for video None"). Per-video thumbnail
+        # fetching for the videos[] loop is handled separately downstream.
+        if video_id and not thumbnail_url:
             try:
                 video_info = await make_api_request(
                     video_id, access_token, {"fields": "picture"}

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -629,3 +629,60 @@ async def test_video_creative_without_instagram_actor_id_uses_simple_path():
         assert "object_story_spec" in creative_data
         assert "video_data" in creative_data["object_story_spec"]
         assert "instagram_user_id" not in creative_data["object_story_spec"]
+
+
+@pytest.mark.asyncio
+async def test_videos_array_does_not_trigger_thumbnail_fetch_with_none():
+    """Regression: when only videos=[...] is passed (no singular video_id, no thumbnail_url),
+    the singular-video thumbnail auto-fetch must NOT call Meta with video_id=None.
+
+    Previously the guard was `if is_video and not thumbnail_url`, where
+    `is_video = bool(video_id or videos)`. That meant the videos=[...] path also
+    triggered the singular-video thumbnail fetch — which then called
+    make_api_request(None, ...) and Meta returned a generic error logged as
+    "Could not auto-fetch thumbnail for video None".
+
+    The fix tightens the guard to `if video_id and not thumbnail_url`, so the
+    singular-video fetch only runs when video_id is actually set.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # POST create creative (no thumbnail auto-fetch precedes this)
+            {"id": "creative_videos_arr"},
+            # GET creative details
+            {"id": "creative_videos_arr", "name": "Videos Array Creative", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[{"video_id": "vid_videos_arr"}],  # plural form, no thumbnail_url
+            name="Videos Array Test",
+            link_url="https://example.com/",
+            access_token="test_token",
+        )
+
+        # Exactly two calls: POST create + GET details. No thumbnail auto-fetch
+        # should have been issued for the singular video_id branch.
+        assert mock_api.call_count == 2, (
+            f"Expected exactly 2 API calls (POST create + GET details), "
+            f"got {mock_api.call_count}: "
+            f"{[c.args[0] for c in mock_api.call_args_list]}"
+        )
+
+        # And critically, none of the calls should have been made with None as the
+        # first positional argument (which is what the buggy guard produced).
+        for call in mock_api.call_args_list:
+            assert call.args[0] is not None, (
+                f"make_api_request was called with None as the first arg "
+                f"(args={call.args!r}); the singular-video thumbnail auto-fetch "
+                f"should be skipped when only videos=[...] is provided"
+            )


### PR DESCRIPTION
## Summary

When `create_ad_creative` is called with the plural `videos=[...]` form (and no singular `video_id` and no `thumbnail_url`), the singular-video thumbnail auto-fetch was reached anyway. The guard was `if is_video and not thumbnail_url` where `is_video = bool(video_id or videos)`, so the plural path also entered the block and called Meta with `video_id=None`:

```python
if is_video and not thumbnail_url:
    video_info = await make_api_request(video_id, access_token, {"fields": "picture"})  # video_id is None here
    ...
    logger.warning(f"Could not auto-fetch thumbnail for video {video_id}: {video_info}")
```

Meta returns a generic error and the warning logs as **`Could not auto-fetch thumbnail for video None`** — wasted API call, noisy logs, and confusing for debugging.

## Fix

One-line change: guard on `video_id` instead of `is_video` so the singular auto-fetch only runs when `video_id` is actually set. Per-video thumbnail fetching for the `videos[]` loop is intentionally out of scope here and will be addressed in a follow-up PR.

## Tests

- New regression test `test_videos_array_does_not_trigger_thumbnail_fetch_with_none` in `tests/test_video_creatives.py` asserts that the plural `videos=[...]` form does **not** trigger the singular auto-fetch (no `make_api_request(None, ...)` call).
- All existing `test_video_creatives.py`, `test_object_story_id.py`, `test_create_ad_creative_simple.py`, `test_flex_creatives.py` continue to pass (50/50).
- Full pre-commit pytest suite passes (398 passed, 8 skipped, 26 deselected).

## E2E verification

Verified end-to-end against the real Meta API (account `act_1276764704512927`, real video):

1. **Singular `video_id` path** still works correctly. The auto-fetch ran, retrieved a thumbnail URL, and the creative was created (id `1001578948882264`). Log line: `Auto-fetched video thumbnail: https://...`.
2. **Plural `videos=[...]` path** no longer issues the spurious singular fetch. With debug logs captured in-process, **no** `Could not auto-fetch thumbnail for video None` warning is emitted. Meta still returns a 1487390 error for this combo (PLACEMENT + videos[]) — that is a separate issue handled in subsequent PRs.

## Scope

Split out from #85 (closed) to keep this change small and focused. Subsequent follow-ups will cover:

- Per-video thumbnail fetching inside the `videos[]` loop
- `object_story_spec` shape adjustments
- Any v25 routing changes

Refs feedback task n_3fa6881c-9009-4e62-849d-ba0d69068ee1.

## Test plan

- [x] Unit tests pass (`pytest tests/test_video_creatives.py`)
- [x] Regression suite passes (`pytest tests/test_video_creatives.py tests/test_object_story_id.py tests/test_create_ad_creative_simple.py tests/test_flex_creatives.py`)
- [x] Full pre-commit suite passes
- [x] E2E: singular `video_id` still successfully creates a video creative
- [x] E2E: plural `videos=[...]` no longer logs `video None` warning