### PR TITLE
fix(ads): auto-fetch thumbnails for videos[] entries in create_ad_creative

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1,5 +1,6 @@
 """Ad and Creative-related functionality for Meta Ads API."""
 
+import asyncio
 import json
 import logging
 from typing import Optional, Dict, Any, List, Union
@@ -1482,6 +1483,25 @@ async def compute_image_crops(
     return json.dumps(result, indent=2)
 
 
+async def _fetch_video_thumbnail(vid_id: str, access_token: str) -> Optional[str]:
+    """Fetch a thumbnail URL for a Meta video. Returns None on any failure.
+
+    Prefers the pre-generated `thumbnails.data[0].uri` over `picture` because
+    `picture` can sometimes be a small placeholder while the thumbnails entry
+    is the actual generated frame Meta uses for video previews.
+    """
+    try:
+        info = await make_api_request(vid_id, access_token, {"fields": "picture,thumbnails"})
+        if isinstance(info, dict):
+            thumbs = info.get("thumbnails", {}).get("data", [])
+            if thumbs and thumbs[0].get("uri"):
+                return thumbs[0]["uri"]
+            return info.get("picture") or None
+    except Exception as e:
+        logger.warning(f"Failed to auto-fetch thumbnail for video {vid_id}: {e}")
+    return None
+
+
 @mcp_server.tool()
 @meta_api_tool
 async def create_ad_creative(
@@ -1971,17 +1991,12 @@ async def create_ad_creative(
         # ("Could not auto-fetch thumbnail for video None"). Per-video thumbnail
         # fetching for the videos[] loop is handled separately downstream.
         if video_id and not thumbnail_url:
-            try:
-                video_info = await make_api_request(
-                    video_id, access_token, {"fields": "picture"}
-                )
-                if isinstance(video_info, dict) and "picture" in video_info:
-                    thumbnail_url = video_info["picture"]
-                    logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
-                else:
-                    logger.warning(f"Could not auto-fetch thumbnail for video {video_id}: {video_info}")
-            except Exception as e:
-                logger.warning(f"Failed to auto-fetch thumbnail for video {video_id}: {e}")
+            fetched = await _fetch_video_thumbnail(video_id, access_token)
+            if fetched:
+                thumbnail_url = fetched
+                logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
+            else:
+                logger.warning(f"Could not auto-fetch thumbnail for video {video_id}")
 
         if object_story_id:
             # ---------------------------------------------------------------------------
@@ -2028,12 +2043,39 @@ async def create_ad_creative(
             videos_array = None
             images_array = None
             if videos:
-                # Multiple videos with placement labels (e.g., 1:1 Feed + 9:16 Reels)
+                # Multiple videos with placement labels (e.g., 1:1 Feed + 9:16 Reels).
+                # Auto-fetch missing thumbnails in parallel — Meta API v24 requires a
+                # thumbnail (image_hash or image_url) for each entry in
+                # asset_feed_spec.videos[]. Without it, creates fail with error 1443226
+                # ("Please specify one of image_hash or image_url in the video_data
+                # field of object_story_spec"). Parallel fetch via asyncio.gather to
+                # avoid N sequential round trips for N videos.
+                thumb_coros = [
+                    _fetch_video_thumbnail(str(v["video_id"]), access_token)
+                    for v in videos if not v.get("thumbnail_url")
+                ]
+                fetched_iter = iter(await asyncio.gather(*thumb_coros) if thumb_coros else [])
                 videos_array = []
                 for v in videos:
-                    entry = {"video_id": str(v["video_id"])}
+                    vid_id = str(v["video_id"])
+                    entry: Dict[str, Any] = {"video_id": vid_id}
                     if v.get("thumbnail_url"):
                         entry["thumbnail_url"] = v["thumbnail_url"]
+                    else:
+                        fetched_thumb = next(fetched_iter, None)
+                        if fetched_thumb:
+                            entry["thumbnail_url"] = fetched_thumb
+                            logger.info(
+                                f"Auto-fetched thumbnail for video {vid_id}: "
+                                f"{str(fetched_thumb)[:80]}..."
+                            )
+                        else:
+                            # Proceed without a thumbnail; Meta will return its own
+                            # actionable error (1443226) if it actually requires one.
+                            logger.warning(
+                                f"Could not auto-fetch thumbnail for video {vid_id}; "
+                                f"proceeding without thumbnail_url"
+                            )
                     if v.get("label"):
                         entry["adlabels"] = [{"name": v["label"]}]
                     elif v.get("adlabels"):

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -647,6 +647,10 @@ async def test_videos_array_does_not_trigger_thumbnail_fetch_with_none():
 
     The fix tightens the guard to `if video_id and not thumbnail_url`, so the
     singular-video fetch only runs when video_id is actually set.
+
+    Note: the videos[] branch DOES auto-fetch per-entry thumbnails (each call uses
+    the actual entry's video_id, never None). This regression test specifically
+    asserts that no call is ever made with `None` as the first positional arg.
     """
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
@@ -659,9 +663,11 @@ async def test_videos_array_does_not_trigger_thumbnail_fetch_with_none():
         }
 
         mock_api.side_effect = [
-            # POST create creative (no thumbnail auto-fetch precedes this)
+            # 1) Per-video thumbnail auto-fetch (videos[] branch) — uses real vid_id
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            # 2) POST create creative
             {"id": "creative_videos_arr"},
-            # GET creative details
+            # 3) GET creative details
             {"id": "creative_videos_arr", "name": "Videos Array Creative", "status": "ACTIVE"},
         ]
 
@@ -673,15 +679,7 @@ async def test_videos_array_does_not_trigger_thumbnail_fetch_with_none():
             access_token="test_token",
         )
 
-        # Exactly two calls: POST create + GET details. No thumbnail auto-fetch
-        # should have been issued for the singular video_id branch.
-        assert mock_api.call_count == 2, (
-            f"Expected exactly 2 API calls (POST create + GET details), "
-            f"got {mock_api.call_count}: "
-            f"{[c.args[0] for c in mock_api.call_args_list]}"
-        )
-
-        # And critically, none of the calls should have been made with None as the
+        # Critically, none of the calls should have been made with None as the
         # first positional argument (which is what the buggy guard produced).
         for call in mock_api.call_args_list:
             assert call.args[0] is not None, (
@@ -843,9 +841,13 @@ async def test_create_ad_creative_videos_with_placement_rules_sends_correct_payl
         }
 
         mock_api.side_effect = [
-            # 1) POST create creative
+            # 1) Per-video thumbnail auto-fetch for vidA (videos[] branch)
+            {"picture": "https://example.com/vidA-thumb.jpg"},
+            # 2) Per-video thumbnail auto-fetch for vidB
+            {"picture": "https://example.com/vidB-thumb.jpg"},
+            # 3) POST create creative
             {"id": "creative_vid_rules"},
-            # 2) GET creative details
+            # 4) GET creative details
             {"id": "creative_vid_rules", "name": "Video Placement Rules", "status": "ACTIVE"},
         ]
 
@@ -873,9 +875,10 @@ async def test_create_ad_creative_videos_with_placement_rules_sends_correct_payl
             access_token="test_token",
         )
 
-        # No thumbnail auto-fetch (no singular video_id)
-        assert mock_api.call_count == 2
-        creative_data = mock_api.call_args_list[0][0][2]
+        # 2 thumbnail auto-fetches + POST + GET details = 4 calls
+        assert mock_api.call_count == 4
+        # POST is the 3rd call (after the two thumbnail GETs)
+        creative_data = mock_api.call_args_list[2][0][2]
 
         assert "asset_feed_spec" in creative_data
         afs = creative_data["asset_feed_spec"]
@@ -916,3 +919,197 @@ async def test_create_ad_creative_videos_with_placement_rules_sends_correct_payl
         assert "story" in story_rule["customization_spec"]["facebook_positions"]
         assert "story" in story_rule["customization_spec"]["instagram_positions"]
         assert story_rule["video_label"] == {"name": "PBOARD_VID_1"}
+
+
+# ---------------------------------------------------------------------------
+# Per-video thumbnail auto-fetch in the videos=[...] branch (PR-B)
+# ---------------------------------------------------------------------------
+# Meta API v24 requires a thumbnail (image_hash or image_url) for each entry
+# in asset_feed_spec.videos[]. Without it, creates fail with error 1443226
+# ("Please specify one of image_hash or image_url in the video_data field
+# of object_story_spec"). These tests cover the per-entry auto-fetch the
+# videos[] path performs in parallel.
+
+
+@pytest.mark.asyncio
+async def test_videos_array_auto_fetches_missing_thumbnails():
+    """When entries in videos=[...] have no thumbnail_url, fetch each one in parallel
+    via {video_id}?fields=picture,thumbnails and apply the result to the entry.
+
+    Expected calls: 2 thumbnail GETs (one per video) + 1 POST creative + 1 GET details = 4.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            # 1) Thumbnail fetch for "a"
+            {"picture": "https://example.com/picA.jpg",
+             "thumbnails": {"data": [{"uri": "https://example.com/thumbA.jpg"}]}},
+            # 2) Thumbnail fetch for "b"
+            {"picture": "https://example.com/picB.jpg",
+             "thumbnails": {"data": [{"uri": "https://example.com/thumbB.jpg"}]}},
+            # 3) POST create creative
+            {"id": "creative_auto_thumb"},
+            # 4) GET creative details
+            {"id": "creative_auto_thumb", "name": "Auto Thumb", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[{"video_id": "a"}, {"video_id": "b"}],
+            name="Auto Thumb",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        assert mock_api.call_count == 4, (
+            f"Expected 4 calls (2 thumb GETs + POST + GET details), got "
+            f"{mock_api.call_count}: {[c.args[0] for c in mock_api.call_args_list]}"
+        )
+
+        # First two calls are the thumbnail GETs.
+        thumb_call_a = mock_api.call_args_list[0]
+        thumb_call_b = mock_api.call_args_list[1]
+        # First positional arg is the video_id (endpoint path).
+        ids_fetched = {thumb_call_a.args[0], thumb_call_b.args[0]}
+        assert ids_fetched == {"a", "b"}
+        # Both thumbnail GETs should request picture,thumbnails.
+        for c in (thumb_call_a, thumb_call_b):
+            params = c.args[2]
+            assert params.get("fields") == "picture,thumbnails"
+
+        # POST is the 3rd call. asset_feed_spec.videos must carry the fetched URIs.
+        creative_data = mock_api.call_args_list[2][0][2]
+        afs = creative_data["asset_feed_spec"]
+        videos_out = afs["videos"]
+        assert len(videos_out) == 2
+        by_id = {v["video_id"]: v for v in videos_out}
+        assert by_id["a"]["thumbnail_url"] == "https://example.com/thumbA.jpg"
+        assert by_id["b"]["thumbnail_url"] == "https://example.com/thumbB.jpg"
+
+
+@pytest.mark.asyncio
+async def test_videos_array_uses_provided_thumbnails_without_fetch():
+    """When every videos[] entry already has a thumbnail_url, no auto-fetch should
+    happen. Only POST + GET details = 2 calls.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            {"id": "creative_provided_thumb"},
+            {"id": "creative_provided_thumb", "name": "Provided", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[
+                {"video_id": "a", "thumbnail_url": "https://x"},
+                {"video_id": "b", "thumbnail_url": "https://y"},
+            ],
+            name="Provided Thumb",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        assert mock_api.call_count == 2, (
+            f"Expected 2 calls (POST + GET details), got {mock_api.call_count}: "
+            f"{[c.args[0] for c in mock_api.call_args_list]}"
+        )
+
+        # First call is the POST. Both provided thumbnail_urls preserved verbatim.
+        creative_data = mock_api.call_args_list[0][0][2]
+        afs = creative_data["asset_feed_spec"]
+        by_id = {v["video_id"]: v for v in afs["videos"]}
+        assert by_id["a"]["thumbnail_url"] == "https://x"
+        assert by_id["b"]["thumbnail_url"] == "https://y"
+
+
+@pytest.mark.asyncio
+async def test_video_thumbnail_fetch_prefers_thumbnails_uri_over_picture():
+    """`_fetch_video_thumbnail` must prefer the pre-generated thumbnails.data[0].uri
+    over the `picture` field, since `picture` can be a small placeholder while
+    thumbnails carries the actual generated frame.
+    """
+    from meta_ads_mcp.core.ads import _fetch_video_thumbnail
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api:
+        mock_api.return_value = {
+            "picture": "https://example.com/placeholder-picture.jpg",
+            "thumbnails": {
+                "data": [
+                    {"uri": "https://example.com/preferred-thumb.jpg"},
+                    {"uri": "https://example.com/another-thumb.jpg"},
+                ]
+            },
+        }
+
+        result = await _fetch_video_thumbnail("vid_123", "test_token")
+
+        assert result == "https://example.com/preferred-thumb.jpg"
+        # Sanity: it should have asked for both fields.
+        params = mock_api.call_args.args[2]
+        assert params.get("fields") == "picture,thumbnails"
+
+
+@pytest.mark.asyncio
+async def test_videos_array_proceeds_when_thumbnail_fetch_fails():
+    """If the thumbnail fetch returns nothing usable (empty/None), the videos[]
+    path should still proceed. The entry simply ships without a thumbnail_url —
+    Meta will return its own actionable error if it actually needs one.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            # 1) Thumbnail fetch: API returned an empty dict (no picture, no thumbnails)
+            {},
+            # 2) POST create creative
+            {"id": "creative_fail_thumb"},
+            # 3) GET creative details
+            {"id": "creative_fail_thumb", "name": "Fail Thumb", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[{"video_id": "vid_no_thumb"}],
+            name="Fail Thumb",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        assert mock_api.call_count == 3
+        creative_data = mock_api.call_args_list[1][0][2]
+        afs = creative_data["asset_feed_spec"]
+        videos_out = afs["videos"]
+        assert len(videos_out) == 1
+        # No thumbnail_url on the entry — graceful degradation.
+        assert "thumbnail_url" not in videos_out[0]
+        assert videos_out[0]["video_id"] == "vid_no_thumb"


### PR DESCRIPTION
## Bug

`create_ad_creative` with `videos=[...]` (the plural placement-customization form) requires the caller to set `thumbnail_url` on every entry. Without one, Meta API v24 returns:

```
1443226 — Please specify one of image_hash or image_url in the video_data field of object_story_spec
```

The singular `video_id` path already auto-fetched a thumbnail; the plural path did not. This PR brings the plural path to parity.

## Change

- New helper `_fetch_video_thumbnail(vid_id, access_token) -> Optional[str]`
  - GETs `{video_id}?fields=picture,thumbnails`
  - Prefers `thumbnails.data[0].uri` over `picture` (the pre-generated URI is more reliable; `picture` can be a small placeholder)
  - Returns `None` on any failure (logs a warning, never raises)
- Singular `video_id` block refactored to use the helper. Behavior identical.
- In the `if videos:` branch of `asset_feed_spec`, fetch missing thumbnails in parallel via `asyncio.gather`. If a fetch fails, proceed without `thumbnail_url` and log a warning naming the video id  Meta returns its own actionable error if it actually requires one.

This is purely additive: no shape changes to `object_story_spec` (PR-C), no v25 routing, no bulk-handler changes.

## Context

Split out from closed PR #85. Sequence:

- PR #86 (PR-A) merged  guard fix so the singular path does not run with `video_id=None` when caller used `videos=[...]`
- PR #87 (PR-D) merged  `placement_groups` rule translation for `videos[]` path
- This PR (PR-B)  auto-fetch thumbnails for `videos[]` entries
- PR-C and PR-E to follow separately

Feedback task: `n_3fa6881c-9009-4e62-849d-ba0d69068ee1`

## Tests

Added 4 new tests in `tests/test_video_creatives.py`:

1. `test_videos_array_auto_fetches_missing_thumbnails`  2 thumbnail GETs + POST + GET-details; assert each entry receives the fetched `thumbnail_url`
2. `test_videos_array_uses_provided_thumbnails_without_fetch`  no fetches when caller provides thumbnails
3. `test_video_thumbnail_fetch_prefers_thumbnails_uri_over_picture`  helper preference check
4. `test_videos_array_proceeds_when_thumbnail_fetch_fails`  graceful degradation when API returns an empty payload

Two existing tests updated to account for the new auto-fetch calls in their mocks (call counts and side_effect lists).

Full test run: `431 passed, 9 skipped`.

## E2E verification

Local Python servers on ports 9000 + 9001 against test account `act_1276764704512927` with the two videos PR-D used (`1659549855472960` + `2078250659388185`):

1. `videos=[{video_id: A}, {video_id: B}]`, no `thumbnail_url`, no `asset_customization_rules`  Meta accepted the creative (id `1580577789672516`). Response confirms `thumbnail_url` and `thumbnail_hash` were populated for both entries.
2. Same call with explicit `thumbnail_url` per entry  also accepted (id `800454559803337`); thumbnails passed through verbatim.

Both cases return `success: true`. No `1443226` errors.