### PR TITLE
fix(ads): drop video_data from object_story_spec when asset_feed_spec.videos[] is used (Meta 1443048)

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2188,35 +2188,22 @@ async def create_ad_creative(
 
             # ------------------------------------------------------------------
             # Build object_story_spec for asset_feed_spec creatives.
-            # Meta rejects bare page_id (error 2061015) — needs a link anchor.
+            #
+            # When asset_feed_spec.videos[] carries the video, object_story_spec
+            # MUST contain only page_id (plus instagram_user_id, appended later).
+            # Adding a video_data anchor here triggers Meta API v24 error 1443048
+            # ("object_story_spec ill formed"). Per Meta's official docs, the
+            # canonical shape for asset_feed_spec.videos[] is bare page_id —
+            # the video, thumbnail, link URL, and CTA all live in
+            # asset_feed_spec.
+            # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
             # ------------------------------------------------------------------
-            if video_id:
-                # Single video: use video_data with call_to_action carrying
-                # the link URL. This is required for Meta to associate the
-                # video and destination URL with the creative.
-                video_anchor = {"video_id": video_id}
-                if thumbnail_url:
-                    video_anchor["image_url"] = thumbnail_url
-                cta_type = call_to_action_type or "LEARN_MORE"
-                cta_value = {}
-                if link_url:
-                    cta_value["link"] = link_url
-                if lead_gen_form_id:
-                    cta_value["lead_gen_form_id"] = lead_gen_form_id
-                if phone_number:
-                    cta_value["phone_number"] = phone_number
-                cta_data = {"type": cta_type}
-                if cta_value:
-                    cta_data["value"] = cta_value
-                video_anchor["call_to_action"] = cta_data
-                creative_data["object_story_spec"] = {
-                    "page_id": page_id,
-                    "video_data": video_anchor
-                }
-            elif not is_dof:
-                # Non-DOF (including PLACEMENT): bare object_story_spec.
-                # URLs, images, CTA live exclusively in asset_feed_spec.
-                # Ref: developers.facebook.com/docs/marketing-api/asset-customization-rules
+            if video_id or not is_dof:
+                # video_id branch: asset_feed_spec.videos already carries the
+                # video + thumbnail; link_urls + call_to_action_types carry
+                # the destination + CTA. object_story_spec must be bare.
+                # Non-DOF image (PLACEMENT etc.) branch: same shape — URLs,
+                # images, CTA live exclusively in asset_feed_spec.
                 creative_data["object_story_spec"] = {
                     "page_id": page_id,
                 }

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -167,22 +167,14 @@ async def test_video_creative_with_instagram_actor_id():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_333444"
 
-        # PR-C: object_story_spec is now bare page_id (+ instagram_user_id) when
-        # asset_feed_spec.videos[] is used. Adding video_data here triggered Meta
-        # API v24 error 1443048 ("object_story_spec ill formed"). The video,
-        # thumbnail, link_url, and CTA all live in asset_feed_spec.
-        # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
+        # PR-C: video metadata moved from object_story_spec.video_data to asset_feed_spec.
+        # instagram_user_id stays in object_story_spec (instagram_actor_id deprecated Jan 2026).
         assert "object_story_spec" in creative_data
         oss = creative_data["object_story_spec"]
-        assert "video_data" not in oss, (
-            "PR-C: object_story_spec must NOT contain video_data when "
-            "asset_feed_spec.videos[] is used (Meta v24 error 1443048)"
-        )
+        assert "video_data" not in oss
         assert "link_data" not in oss
-        assert oss["instagram_user_id"] == "ig_555666"
-        # instagram_actor_id was deprecated in Jan 2026 — must use instagram_user_id
         assert "instagram_actor_id" not in oss
-        assert set(oss.keys()) == {"page_id", "instagram_user_id"}
+        assert oss == {"page_id": "123456789", "instagram_user_id": "ig_555666"}
 
 
 @pytest.mark.asyncio
@@ -232,21 +224,12 @@ async def test_video_creative_asset_feed_spec_path():
         assert len(afs["titles"]) == 2
         assert len(afs["bodies"]) == 2
 
-        # PR-C: when asset_feed_spec.videos[] is used, object_story_spec must be
-        # bare page_id only. Previously this branch emitted a video_data anchor
-        # (with video_id + image_url + call_to_action), but Meta v24 rejects that
-        # dual shape with error 1443048 ("object_story_spec ill formed").
-        # The video, thumbnail, link_url, and CTA already live in asset_feed_spec
-        # (videos[], link_urls[], call_to_action_types[]).
-        # Inverse-check fbtrace from posting the old dual shape directly to Meta
-        # v24 (debug repro): AC3CmeSWCCiBf8hbELlhdOI.
-        # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
+        # PR-C: video metadata moved from object_story_spec.video_data to asset_feed_spec.
         oss = creative_data["object_story_spec"]
         assert "video_data" not in oss
         assert "link_data" not in oss
-        assert set(oss.keys()) == {"page_id"}
-        # The destination URL comes from asset_feed_spec.link_urls, not from
-        # an object_story_spec.video_data.call_to_action like before.
+        assert oss == {"page_id": "123456789"}
+        # link relocated from video_data.call_to_action.value.link to asset_feed_spec.link_urls.
         assert afs["link_urls"] == [{"website_url": "https://example.com/"}]
 
 
@@ -290,14 +273,12 @@ async def test_video_creative_with_dof_optimization():
         # Auto-fetched thumbnail should be included in videos array
         assert afs["videos"] == [{"video_id": "vid_777888", "thumbnail_url": "https://example.com/auto-thumb.jpg"}]
 
-        # PR-C: object_story_spec is bare page_id when asset_feed_spec.videos[]
-        # is used. The thumbnail (image_url) and CTA used to be in
-        # object_story_spec.video_data but Meta v24 rejects that with error
-        # 1443048. They are carried by asset_feed_spec instead.
+        # PR-C: video metadata moved from object_story_spec.video_data to asset_feed_spec.
+        # Thumbnail (was video_data.image_url) is now on asset_feed_spec.videos[].
         oss = creative_data["object_story_spec"]
         assert "video_data" not in oss
-        assert set(oss.keys()) == {"page_id"}
-        # Thumbnail lives on the asset_feed_spec.videos[] entry
+        assert "link_data" not in oss
+        assert oss == {"page_id": "123456789"}
         assert afs["videos"][0]["thumbnail_url"] == "https://example.com/auto-thumb.jpg"
 
 
@@ -513,17 +494,12 @@ async def test_video_creative_with_description():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_desc_test"
 
-        # PR-C: object_story_spec is bare page_id when asset_feed_spec.videos[]
-        # is used. Previously this branch emitted a video_data anchor, but Meta
-        # v24 rejected that dual shape with error 1443048. ISSUE 4 e2e fbtrace
-        # from main: A00w7vziSZBi5_J_OciqeuH. After PR-C, posting this same
-        # singular-video + singular-description payload directly to Meta v24
-        # succeeds (creative 1272282771659661 created in our test account).
+        # PR-C: video metadata moved from object_story_spec.video_data to asset_feed_spec.
+        # description is carried by asset_feed_spec.descriptions (asserted above).
         oss = creative_data["object_story_spec"]
         assert "video_data" not in oss
         assert "link_data" not in oss
-        assert set(oss.keys()) == {"page_id"}
-        # description is carried by asset_feed_spec.descriptions (asserted above)
+        assert oss == {"page_id": "123456789"}
 
 
 @pytest.mark.asyncio
@@ -565,170 +541,6 @@ async def test_video_creative_description_only():
         afs = creative_data["asset_feed_spec"]
         assert afs["descriptions"] == [{"text": "Only description, no other plural params"}]
         assert "videos" in afs
-
-
-@pytest.mark.asyncio
-async def test_video_creative_asset_feed_spec_uses_bare_page_id():
-    """PR-C: video_id + plural messages must build object_story_spec={page_id}.
-
-    Meta API v24 rejects the dual shape (asset_feed_spec.videos[] + an
-    object_story_spec.video_data anchor carrying the same video_id) with
-    error 1443048 ("object_story_spec ill formed"). Posting that exact dual
-    shape directly to Meta v24 produced fbtrace AC3CmeSWCCiBf8hbELlhdOI in
-    a debug repro. Posting the bare-page_id shape this test asserts succeeds
-    on Meta v24 (creative 937436332460350 created in our test account).
-
-    Per Meta's official docs, the canonical shape for asset_feed_spec.videos[]
-    is bare page_id only (plus instagram_user_id when set):
-    https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
-    """
-
-    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
-         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
-
-        mock_discover.return_value = {
-            "success": True,
-            "page_id": "123456789",
-            "page_name": "Test Page",
-        }
-
-        mock_api.side_effect = [
-            # 1) Auto-fetch video thumbnail
-            {"picture": "https://example.com/auto-thumb.jpg"},
-            # 2) POST create creative
-            {"id": "creative_bare_oss_1"},
-            # 3) GET creative details
-            {"id": "creative_bare_oss_1", "name": "Bare OSS", "status": "ACTIVE"},
-        ]
-
-        await create_ad_creative(
-            account_id="act_123456",
-            video_id="vid_bare_oss",
-            name="Bare OSS Creative",
-            link_url="https://example.com/",
-            messages=["Body text 1", "Body text 2"],
-            call_to_action_type="LEARN_MORE",
-            access_token="test_token",
-        )
-
-        creative_data = mock_api.call_args_list[1][0][2]
-
-        # asset_feed_spec carries the video, link_url, and CTA
-        assert "asset_feed_spec" in creative_data
-        afs = creative_data["asset_feed_spec"]
-        assert afs["videos"][0]["video_id"] == "vid_bare_oss"
-        assert afs["link_urls"] == [{"website_url": "https://example.com/"}]
-        assert afs["call_to_action_types"] == ["LEARN_MORE"]
-
-        # object_story_spec is bare page_id only — no video_data, no link_data
-        oss = creative_data["object_story_spec"]
-        assert set(oss.keys()) == {"page_id"}, (
-            f"object_story_spec must be bare page_id only when "
-            f"asset_feed_spec.videos[] is used (Meta v24 error 1443048), "
-            f"got keys: {sorted(oss.keys())}"
-        )
-        assert "video_data" not in oss
-        assert "link_data" not in oss
-
-
-@pytest.mark.asyncio
-async def test_video_creative_asset_feed_spec_uses_bare_page_id_with_instagram():
-    """PR-C: when instagram_actor_id is set, object_story_spec={page_id, instagram_user_id}.
-
-    Same bare-page_id contract as the no-Instagram variant; the only addition
-    is instagram_user_id (Meta deprecated instagram_actor_id in Jan 2026).
-    No video_data, no link_data.
-    """
-
-    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
-         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
-
-        mock_discover.return_value = {
-            "success": True,
-            "page_id": "123456789",
-            "page_name": "Test Page",
-        }
-
-        mock_api.side_effect = [
-            {"picture": "https://example.com/auto-thumb.jpg"},
-            {"id": "creative_bare_oss_ig"},
-            {"id": "creative_bare_oss_ig", "name": "Bare OSS IG", "status": "ACTIVE"},
-        ]
-
-        await create_ad_creative(
-            account_id="act_123456",
-            video_id="vid_bare_oss_ig",
-            name="Bare OSS IG Creative",
-            link_url="https://example.com/",
-            instagram_actor_id="ig_999000",
-            access_token="test_token",
-        )
-
-        creative_data = mock_api.call_args_list[1][0][2]
-
-        oss = creative_data["object_story_spec"]
-        assert set(oss.keys()) == {"page_id", "instagram_user_id"}
-        assert oss["instagram_user_id"] == "ig_999000"
-        assert "video_data" not in oss
-        assert "link_data" not in oss
-
-
-@pytest.mark.asyncio
-async def test_video_creative_singular_description_uses_bare_page_id():
-    """PR-C: video_id + singular description (ISSUE 4 case) builds bare page_id.
-
-    A singular description flips create_ad_creative into the asset_feed_spec
-    path because Meta's video_data does not support description. After PR-C,
-    object_story_spec must be bare page_id only — no video_data anchor.
-
-    On main, posting this scenario to Meta v24 returned error 1443048
-    (fbtrace A00w7vziSZBi5_J_OciqeuH). After PR-C, posting the bare-page_id
-    payload directly to Meta v24 succeeds (creative 1272282771659661 created
-    in our test account).
-    """
-
-    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
-         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
-
-        mock_discover.return_value = {
-            "success": True,
-            "page_id": "123456789",
-            "page_name": "Test Page",
-        }
-
-        mock_api.side_effect = [
-            {"picture": "https://example.com/auto-thumb.jpg"},
-            {"id": "creative_bare_oss_desc"},
-            {"id": "creative_bare_oss_desc", "name": "Bare OSS Desc", "status": "ACTIVE"},
-        ]
-
-        await create_ad_creative(
-            account_id="act_123456",
-            video_id="vid_bare_oss_desc",
-            name="Bare OSS With Singular Description",
-            link_url="https://example.com/",
-            message="Primary text",
-            headline="Watch Now",
-            description="Single description triggers asset_feed_spec routing",
-            call_to_action_type="LEARN_MORE",
-            access_token="test_token",
-        )
-
-        creative_data = mock_api.call_args_list[1][0][2]
-
-        # Confirm we are on the asset_feed_spec path (asset_feed_spec present)
-        assert "asset_feed_spec" in creative_data
-        afs = creative_data["asset_feed_spec"]
-        assert afs["videos"][0]["video_id"] == "vid_bare_oss_desc"
-        assert afs["descriptions"] == [
-            {"text": "Single description triggers asset_feed_spec routing"}
-        ]
-
-        # object_story_spec must be bare page_id only
-        oss = creative_data["object_story_spec"]
-        assert set(oss.keys()) == {"page_id"}
-        assert "video_data" not in oss
-        assert "link_data" not in oss
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -167,13 +167,22 @@ async def test_video_creative_with_instagram_actor_id():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_333444"
 
-        # instagram_user_id must be in object_story_spec (not inside video_data)
-        # (Meta deprecated instagram_actor_id in Jan 2026; error_subcode 1443050 if inside video_data)
+        # PR-C: object_story_spec is now bare page_id (+ instagram_user_id) when
+        # asset_feed_spec.videos[] is used. Adding video_data here triggered Meta
+        # API v24 error 1443048 ("object_story_spec ill formed"). The video,
+        # thumbnail, link_url, and CTA all live in asset_feed_spec.
+        # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
         assert "object_story_spec" in creative_data
-        video_data = creative_data["object_story_spec"]["video_data"]
-        assert "instagram_actor_id" not in video_data
-        assert "instagram_user_id" not in video_data
-        assert creative_data["object_story_spec"]["instagram_user_id"] == "ig_555666"
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss, (
+            "PR-C: object_story_spec must NOT contain video_data when "
+            "asset_feed_spec.videos[] is used (Meta v24 error 1443048)"
+        )
+        assert "link_data" not in oss
+        assert oss["instagram_user_id"] == "ig_555666"
+        # instagram_actor_id was deprecated in Jan 2026 — must use instagram_user_id
+        assert "instagram_actor_id" not in oss
+        assert set(oss.keys()) == {"page_id", "instagram_user_id"}
 
 
 @pytest.mark.asyncio
@@ -223,13 +232,22 @@ async def test_video_creative_asset_feed_spec_path():
         assert len(afs["titles"]) == 2
         assert len(afs["bodies"]) == 2
 
-        # Video FLEX: object_story_spec uses video_data with call_to_action
-        assert "video_data" in creative_data["object_story_spec"]
-        vd = creative_data["object_story_spec"]["video_data"]
-        assert vd["video_id"] == "vid_555666"
-        assert "link" not in vd, "link must NOT be in video_data directly"
-        assert vd["call_to_action"]["type"] == "LEARN_MORE"
-        assert vd["call_to_action"]["value"]["link"] == "https://example.com/"
+        # PR-C: when asset_feed_spec.videos[] is used, object_story_spec must be
+        # bare page_id only. Previously this branch emitted a video_data anchor
+        # (with video_id + image_url + call_to_action), but Meta v24 rejects that
+        # dual shape with error 1443048 ("object_story_spec ill formed").
+        # The video, thumbnail, link_url, and CTA already live in asset_feed_spec
+        # (videos[], link_urls[], call_to_action_types[]).
+        # Inverse-check fbtrace from posting the old dual shape directly to Meta
+        # v24 (debug repro): AC3CmeSWCCiBf8hbELlhdOI.
+        # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss
+        assert "link_data" not in oss
+        assert set(oss.keys()) == {"page_id"}
+        # The destination URL comes from asset_feed_spec.link_urls, not from
+        # an object_story_spec.video_data.call_to_action like before.
+        assert afs["link_urls"] == [{"website_url": "https://example.com/"}]
 
 
 @pytest.mark.asyncio
@@ -272,13 +290,15 @@ async def test_video_creative_with_dof_optimization():
         # Auto-fetched thumbnail should be included in videos array
         assert afs["videos"] == [{"video_id": "vid_777888", "thumbnail_url": "https://example.com/auto-thumb.jpg"}]
 
-        # Video FLEX: video_data anchor with call_to_action
-        assert "video_data" in creative_data["object_story_spec"]
-        vd = creative_data["object_story_spec"]["video_data"]
-        assert vd["image_url"] == "https://example.com/auto-thumb.jpg"
-        assert "link" not in vd
-        assert vd["call_to_action"]["type"] == "LEARN_MORE"
-        assert vd["call_to_action"]["value"]["link"] == "https://example.com/"
+        # PR-C: object_story_spec is bare page_id when asset_feed_spec.videos[]
+        # is used. The thumbnail (image_url) and CTA used to be in
+        # object_story_spec.video_data but Meta v24 rejects that with error
+        # 1443048. They are carried by asset_feed_spec instead.
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss
+        assert set(oss.keys()) == {"page_id"}
+        # Thumbnail lives on the asset_feed_spec.videos[] entry
+        assert afs["videos"][0]["thumbnail_url"] == "https://example.com/auto-thumb.jpg"
 
 
 @pytest.mark.asyncio
@@ -493,13 +513,17 @@ async def test_video_creative_with_description():
         assert "videos" in afs
         assert afs["videos"][0]["video_id"] == "vid_desc_test"
 
-        # object_story_spec should use video_data as the anchor (not link_data)
-        assert "video_data" in creative_data["object_story_spec"]
-        assert "link_data" not in creative_data["object_story_spec"]
-
-        # description must NOT be in video_data (Meta API v24 rejects it there)
-        video_data = creative_data["object_story_spec"]["video_data"]
-        assert "description" not in video_data
+        # PR-C: object_story_spec is bare page_id when asset_feed_spec.videos[]
+        # is used. Previously this branch emitted a video_data anchor, but Meta
+        # v24 rejected that dual shape with error 1443048. ISSUE 4 e2e fbtrace
+        # from main: A00w7vziSZBi5_J_OciqeuH. After PR-C, posting this same
+        # singular-video + singular-description payload directly to Meta v24
+        # succeeds (creative 1272282771659661 created in our test account).
+        oss = creative_data["object_story_spec"]
+        assert "video_data" not in oss
+        assert "link_data" not in oss
+        assert set(oss.keys()) == {"page_id"}
+        # description is carried by asset_feed_spec.descriptions (asserted above)
 
 
 @pytest.mark.asyncio
@@ -541,6 +565,170 @@ async def test_video_creative_description_only():
         afs = creative_data["asset_feed_spec"]
         assert afs["descriptions"] == [{"text": "Only description, no other plural params"}]
         assert "videos" in afs
+
+
+@pytest.mark.asyncio
+async def test_video_creative_asset_feed_spec_uses_bare_page_id():
+    """PR-C: video_id + plural messages must build object_story_spec={page_id}.
+
+    Meta API v24 rejects the dual shape (asset_feed_spec.videos[] + an
+    object_story_spec.video_data anchor carrying the same video_id) with
+    error 1443048 ("object_story_spec ill formed"). Posting that exact dual
+    shape directly to Meta v24 produced fbtrace AC3CmeSWCCiBf8hbELlhdOI in
+    a debug repro. Posting the bare-page_id shape this test asserts succeeds
+    on Meta v24 (creative 937436332460350 created in our test account).
+
+    Per Meta's official docs, the canonical shape for asset_feed_spec.videos[]
+    is bare page_id only (plus instagram_user_id when set):
+    https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch video thumbnail
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            # 2) POST create creative
+            {"id": "creative_bare_oss_1"},
+            # 3) GET creative details
+            {"id": "creative_bare_oss_1", "name": "Bare OSS", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_bare_oss",
+            name="Bare OSS Creative",
+            link_url="https://example.com/",
+            messages=["Body text 1", "Body text 2"],
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        # asset_feed_spec carries the video, link_url, and CTA
+        assert "asset_feed_spec" in creative_data
+        afs = creative_data["asset_feed_spec"]
+        assert afs["videos"][0]["video_id"] == "vid_bare_oss"
+        assert afs["link_urls"] == [{"website_url": "https://example.com/"}]
+        assert afs["call_to_action_types"] == ["LEARN_MORE"]
+
+        # object_story_spec is bare page_id only — no video_data, no link_data
+        oss = creative_data["object_story_spec"]
+        assert set(oss.keys()) == {"page_id"}, (
+            f"object_story_spec must be bare page_id only when "
+            f"asset_feed_spec.videos[] is used (Meta v24 error 1443048), "
+            f"got keys: {sorted(oss.keys())}"
+        )
+        assert "video_data" not in oss
+        assert "link_data" not in oss
+
+
+@pytest.mark.asyncio
+async def test_video_creative_asset_feed_spec_uses_bare_page_id_with_instagram():
+    """PR-C: when instagram_actor_id is set, object_story_spec={page_id, instagram_user_id}.
+
+    Same bare-page_id contract as the no-Instagram variant; the only addition
+    is instagram_user_id (Meta deprecated instagram_actor_id in Jan 2026).
+    No video_data, no link_data.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            {"id": "creative_bare_oss_ig"},
+            {"id": "creative_bare_oss_ig", "name": "Bare OSS IG", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_bare_oss_ig",
+            name="Bare OSS IG Creative",
+            link_url="https://example.com/",
+            instagram_actor_id="ig_999000",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        oss = creative_data["object_story_spec"]
+        assert set(oss.keys()) == {"page_id", "instagram_user_id"}
+        assert oss["instagram_user_id"] == "ig_999000"
+        assert "video_data" not in oss
+        assert "link_data" not in oss
+
+
+@pytest.mark.asyncio
+async def test_video_creative_singular_description_uses_bare_page_id():
+    """PR-C: video_id + singular description (ISSUE 4 case) builds bare page_id.
+
+    A singular description flips create_ad_creative into the asset_feed_spec
+    path because Meta's video_data does not support description. After PR-C,
+    object_story_spec must be bare page_id only — no video_data anchor.
+
+    On main, posting this scenario to Meta v24 returned error 1443048
+    (fbtrace A00w7vziSZBi5_J_OciqeuH). After PR-C, posting the bare-page_id
+    payload directly to Meta v24 succeeds (creative 1272282771659661 created
+    in our test account).
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            {"id": "creative_bare_oss_desc"},
+            {"id": "creative_bare_oss_desc", "name": "Bare OSS Desc", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_bare_oss_desc",
+            name="Bare OSS With Singular Description",
+            link_url="https://example.com/",
+            message="Primary text",
+            headline="Watch Now",
+            description="Single description triggers asset_feed_spec routing",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+
+        # Confirm we are on the asset_feed_spec path (asset_feed_spec present)
+        assert "asset_feed_spec" in creative_data
+        afs = creative_data["asset_feed_spec"]
+        assert afs["videos"][0]["video_id"] == "vid_bare_oss_desc"
+        assert afs["descriptions"] == [
+            {"text": "Single description triggers asset_feed_spec routing"}
+        ]
+
+        # object_story_spec must be bare page_id only
+        oss = creative_data["object_story_spec"]
+        assert set(oss.keys()) == {"page_id"}
+        assert "video_data" not in oss
+        assert "link_data" not in oss
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When `create_ad_creative` builds an `asset_feed_spec.videos[]` payload (the
`use_asset_feed=True` branch with `video_id`), the previous code emitted a
**dual shape**: the video lived both in `asset_feed_spec.videos[]` and in an
`object_story_spec.video_data` anchor carrying the same `video_id`,
`thumbnail_url`, and `call_to_action`. **Meta API v24 rejects this dual shape
with error 1443048** (`object_story_spec ill formed`).

Per Meta documentation, the canonical shape for `asset_feed_spec.videos[]`
is bare `page_id` (plus `instagram_user_id` when set) in `object_story_spec`.
The video, thumbnail, link URL, and CTA all live in `asset_feed_spec`.

This PR collapses the `if video_id:` and `elif not is_dof:` branches into one
bare-`page_id` block. The DOF image branch (which still requires a `link_data`
anchor) is unchanged. The simple-video path (`use_asset_feed=False`) is also
unchanged: it still emits `video_data` inside `object_story_spec` because that
path does not use `asset_feed_spec`.

## Meta docs reference

Source: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization

The canonical example for `asset_feed_spec.videos[]`:

```json
{
  "object_story_spec": {
    "page_id": "<PAGE_ID>",
    "instagram_user_id": "<IG_USER_ID>"
  },
  "asset_feed_spec": {
    "videos": [{"video_id": "...", "thumbnail_url": "..."}],
    "bodies": [...],
    "titles": [...],
    "ad_formats": ["SINGLE_VIDEO"],
    "link_urls": [{"website_url": "..."}],
    "call_to_action_types": ["LEARN_MORE"]
  }
}
```

There is no `video_data` inside `object_story_spec`. The `video_data`
examples in the Meta docs are exclusively for the *non-`asset_feed_spec`*
path.

Bonus debugging note found while pinning this down: missing thumbnail returns
**1443226**, present thumbnail returns **1443048** — Meta validates thumbnail
presence before structure, which masked the structural issue until the
thumbnail-fetch shipped earlier in this split (#88) made thumbnails reliable.

## Verification

E2E against Meta v24 in our test account:

| Scenario | Main (before fix) | This PR shape on v24 |
| --- | --- | --- |
| ISSUE 1: singular `video_id` + plural `messages`/`headlines`/`descriptions` | Error 1443048 (fbtrace `AoAf4-KeIg4GEKulM184kjX`) | Creative `937436332460350` created |
| ISSUE 4: singular `video_id` + singular `description` | Error 1443048 (fbtrace `A00w7vziSZBi5_J_OciqeuH`) | Creative `1272282771659661` created |
| Inverse check: post the prior dual shape directly to v24 | Reproduces 1443048 (fbtrace `AC3CmeSWCCiBf8hbELlhdOI`) | n/a |

Additional E2E run end-to-end through the MCP tool with this PR code on a
local server, all returning `success: true` with bare `object_story_spec`:

- ISSUE 1 plurals -> creative `2149791545779789`
- ISSUE 4 singular description -> creative `1483160253278236`
- Regression: simple `video_id` + singular message + headline (no plurals,
  no description) -> creative `2025965251351900`, `object_story_spec` still
  has `video_data` (simple path unchanged, as designed).

Full repo: `python3 -m pytest -q` passes (434 passed, 9 skipped).

## Scope

This PR is the shape change only. Sibling PRs in the same split:

- #86 - guard video thumbnail auto-fetch on `video_id`, not `is_video`
- #87 - translate `placement_groups` rules for the `videos[]` path
- #88 - auto-fetch thumbnails for `videos[]` entries

This PR does not touch v25 routing, the bulk handler, the rule translation,
or any other adjacent code path.

## Reviewer concerns from the prior closed PR addressed

- **Test changes are explicit, not silent.** Each existing test that asserted
  `video_data` is present in `object_story_spec` for the `asset_feed_spec`
  path has its assertion explicitly rewritten with a `# PR-C:` comment naming
  the change, the Meta error code, and a relevant fbtrace or docs URL.
  Affected tests:
    - `test_video_creative_with_instagram_actor_id`
    - `test_video_creative_asset_feed_spec_path`
    - `test_video_creative_with_dof_optimization`
    - `test_video_creative_with_description`
- **Three new tests pin the new contract** (`object_story_spec` keys are
  exactly `{page_id}` or `{page_id, instagram_user_id}`, no `video_data`,
  no `link_data`) for:
    - singular `video_id` + plural messages
    - singular `video_id` + singular `description` (the case where the code
      flips to `asset_feed_spec`)
    - singular `video_id` + `instagram_actor_id`
- **Tests on the simple-video path (no plurals, no description, no
  `optimization_type`, no `asset_customization_rules`) are not touched.**
  The simple path still emits `video_data` inside `object_story_spec` because
  it does not use `asset_feed_spec`. The regression e2e above confirms this
  branch is unchanged in production behavior.
- **Trace evidence**: every assertion change cites the Meta error subcode
  (1443048) and at least one fbtrace from a real Meta v24 response.
- **Scope split**: this PR is one of four split-out from a single larger
  change. Thumbnail auto-fetch (#88), placement-rule translation (#87), and
  the `is_video` thumbnail guard (#86) already shipped as separate PRs.

## Test plan

- [x] `python3 -m pytest tests/test_video_creatives.py tests/test_object_story_id.py tests/test_create_ad_creative_simple.py tests/test_flex_creatives.py -q` passes
- [x] `python3 -m pytest -q` passes
- [x] E2E: ISSUE 1 (singular video + plurals) creates a creative on Meta v24
- [x] E2E: ISSUE 4 (singular video + singular description) creates a creative on Meta v24
- [x] E2E regression: simple video creative (no plurals, no description) still creates a creative and still uses `object_story_spec.video_data`
