### PR TITLE
Bump version to 1.0.85

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.84"
+__version__ = "1.0.85"
 
 __all__ = [
     'get_ad_accounts',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.84"
+version = "1.0.85"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.84",
+  "version": "1.0.85",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Ships branded content parameters (`facebook_branded_content`, `instagram_branded_content`) on `create_ad_creative`.

The code has been on main since #84 but hasn't been released to PyPI. Production is still on 1.0.84, which does not include these params.

## E2E verified locally

- CLI → Next.js → Python → Meta pipeline passes `facebook_branded_content` through correctly
- Meta returned `(#100) Param facebook_branded_content['sponsor_page_id'] is not a valid page ID` for an invalid test ID, confirming the field reaches the Graph API
- Same for `instagram_branded_content`

## Deploy steps after merge

1. Tag `1.0.85` so the release workflow publishes to PyPI
2. `gh workflow run deploy-meta-ads-mcp.yml -f version=1.0.85` in the pipeboard.co repo