### PR TITLE
feat(adsets): expose bid_adjustments + bump to 1.0.87

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.86"
+__version__ = "1.0.87"
 
 __all__ = [
     'get_ad_accounts',

--- a/meta_ads_mcp/core/adsets.py
+++ b/meta_ads_mcp/core/adsets.py
@@ -29,14 +29,14 @@ async def get_adsets(account_id: str, access_token: Optional[str] = None, limit:
     if campaign_id:
         endpoint = f"{campaign_id}/adsets"
         params = {
-            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
+            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
             "limit": limit
         }
     else:
         # Use account endpoint if no campaign_id is given
         endpoint = f"{account_id}/adsets"
         params = {
-            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
+            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
             "limit": limit
         }
         # Note: Removed the attempt to add campaign_id to params for the account endpoint case, 
@@ -69,7 +69,7 @@ async def get_adset_details(adset_id: str, access_token: Optional[str] = None) -
     endpoint = f"{adset_id}"
     # Explicitly prioritize frequency_control_specs in the fields request
     params = {
-        "fields": "id,name,campaign_id,status,frequency_control_specs{event,interval_days,max_frequency},daily_budget,lifetime_budget,targeting,bid_amount,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,attribution_spec,destination_type,promoted_object,pacing_type,budget_remaining,dsa_beneficiary,dsa_payor,is_dynamic_creative,regional_regulated_categories,regional_regulation_identities"
+        "fields": "id,name,campaign_id,status,frequency_control_specs{event,interval_days,max_frequency},daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,attribution_spec,destination_type,promoted_object,pacing_type,budget_remaining,dsa_beneficiary,dsa_payor,is_dynamic_creative,regional_regulated_categories,regional_regulation_identities"
     }
     
     data = await make_api_request(endpoint, access_token, params)
@@ -98,6 +98,7 @@ async def create_adset(
     bid_amount: Optional[int] = None,
     bid_strategy: Optional[str] = None,
     bid_constraints: Optional[Dict[str, Any]] = None,
+    bid_adjustments: Optional[Dict[str, Any]] = None,
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
     dsa_beneficiary: Optional[str] = None,
@@ -161,6 +162,14 @@ async def create_adset(
         bid_constraints: Bid constraints dict. Required for LOWEST_COST_WITH_MIN_ROAS.
                         Use {"roas_average_floor": <value>} where value = target ROAS * 10000.
                         Example: 2.0x ROAS -> {"roas_average_floor": 20000}
+        bid_adjustments: Bid multipliers per targeting dimension. Pass-through to Meta.
+                        Shape: {"user_groups": {"<dim>": {"<value>": <float>, "default": <float>}}}
+                        Dims: age, gender, user_os, device_platform, position_type,
+                              publisher_platform, user_bucket, home_location, locale, etc.
+                        Multipliers are floats, typically 0.0-1.0.
+                        Example: {"user_groups": {"user_os": {"iOS": 0.9, "Android": 0.7, "default": 1.0}}}
+                        NOTE: Writing bid_adjustments requires a Meta app capability that must be
+                              allowlisted. Apps without it get OAuthException (#3).
         start_time: Start time in ISO 8601 format (e.g., '2023-12-01T12:00:00-0800').
                    To schedule future delivery: set start_time to a future date and status=ACTIVE.
                    Meta will show effective_status as SCHEDULED and automatically begin delivery at start_time.
@@ -398,6 +407,9 @@ async def create_adset(
     if bid_constraints:
         params["bid_constraints"] = json.dumps(bid_constraints)
 
+    if bid_adjustments is not None:
+        params["bid_adjustments"] = json.dumps(bid_adjustments)
+
     if start_time:
         params["start_time"] = start_time
     
@@ -476,6 +488,7 @@ async def create_adset(
 @meta_api_tool
 async def update_adset(adset_id: str, frequency_control_specs: Optional[List[Dict[str, Any]]] = None, bid_strategy: Optional[str] = None,
                         bid_amount: Optional[int] = None, bid_constraints: Optional[Dict[str, Any]] = None,
+                        bid_adjustments: Optional[Dict[str, Any]] = None,
                         name: Optional[str] = None,
                         status: Optional[str] = None, targeting: Optional[Dict[str, Any]] = None,
                         optimization_goal: Optional[str] = None, daily_budget: Optional[int] = None, lifetime_budget: Optional[int] = None,
@@ -508,6 +521,10 @@ async def update_adset(adset_id: str, frequency_control_specs: Optional[List[Dic
         bid_constraints: Bid constraints dict. Required for LOWEST_COST_WITH_MIN_ROAS.
                         Use {"roas_average_floor": <value>} where value = target ROAS * 10000.
                         Example: 2.0x ROAS -> {"roas_average_floor": 20000}
+        bid_adjustments: Bid multipliers per targeting dimension. Pass-through to Meta.
+                        Shape: {"user_groups": {"<dim>": {"<value>": <float>, "default": <float>}}}
+                        See create_adset for full docs and dim list.
+                        NOTE: Writing requires a Meta app capability that must be allowlisted.
         status: Update ad set status (ACTIVE, PAUSED, etc.)
         targeting: Complete targeting specifications (replaces existing targeting)
         optimization_goal: Conversion optimization goal (e.g., 'LINK_CLICKS', 'CONVERSIONS', 'VALUE')
@@ -601,7 +618,10 @@ async def update_adset(adset_id: str, frequency_control_specs: Optional[List[Dic
 
     if bid_constraints is not None:
         params['bid_constraints'] = json.dumps(bid_constraints)
-        
+
+    if bid_adjustments is not None:
+        params['bid_adjustments'] = json.dumps(bid_adjustments)
+
     if status is not None:
         params['status'] = status
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.86"
+version = "1.0.87"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.86",
+  "version": "1.0.87",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
Adds `bid_adjustments` as a pass-through on `create_adset` and `update_adset`, and includes it in the `fields=` query on `get_adsets` and `get_adset_details`.

Shape:
```
{user_groups: {<dim>: {<value>: <float>, default: <float>}}}
```

Writing requires the Meta app capability for bid multipliers — API returns OAuthException (#3) without it. Reads work for any app.

## Test plan
- [x] Pre-commit pytest suite: 415 tests pass locally