### PR TITLE
fix(ads): detect silent single-image collapse in create_ad_creative

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2430,16 +2430,38 @@ async def create_ad_creative(
                 "creative_id": creative_id,
                 "details": creative_details,
             }
+
+            posted_afs = creative_data.get("asset_feed_spec") if isinstance(creative_data.get("asset_feed_spec"), dict) else None
+            posted_images = posted_afs.get("images") if posted_afs else None
+            posted_rules = posted_afs.get("asset_customization_rules") if posted_afs else None
+            stored_afs = creative_details.get("asset_feed_spec") if isinstance(creative_details, dict) else None
+            collapsed = bool(
+                posted_images and len(posted_images) > 1
+                and posted_rules
+                and (not stored_afs or not stored_afs.get("images"))
+            )
+
+            warnings_ = []
             if dof_downgraded:
-                result["warning"] = (
-                    "optimization_type DEGREES_OF_FREEDOM was automatically removed because "
-                    "asset_customization_rules was provided. Meta silently ignores placement "
-                    "rules for DOF creatives. The creative was created using regular dynamic "
-                    "creative mode so placement-specific images are respected. To use DOF "
-                    "instead, remove asset_customization_rules."
+                warnings_.append(
+                    "optimization_type=DEGREES_OF_FREEDOM was dropped because "
+                    "asset_customization_rules was also provided. Whether placement "
+                    "rules take effect depends on the target ad set's "
+                    "is_dynamic_creative capability."
                 )
             elif dof_multi_image_warning:
-                result["warning"] = dof_multi_image_warning
+                warnings_.append(dof_multi_image_warning)
+            if collapsed:
+                warnings_.append(
+                    "Meta silently rewrote this creative from multi-image "
+                    "asset_feed_spec to single-image object_story_spec. Only the "
+                    "first image will serve; asset_customization_rules were "
+                    "discarded. Attach the creative to an ad set with "
+                    "is_dynamic_creative=true, or use image_crops on a single "
+                    "image_hash for per-placement cropping."
+                )
+            if warnings_:
+                result["warning"] = warnings_[0] if len(warnings_) == 1 else warnings_
             return json.dumps(result, indent=2)
 
         return json.dumps(data, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.87"
+version = "1.0.88"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.87",
+  "version": "1.0.88",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_create_ad_creative_collapse_warning.py
+++ b/tests/test_create_ad_creative_collapse_warning.py
@@ -1,0 +1,115 @@
+"""Tests for create_ad_creative readback-based collapse detection."""
+
+import pytest
+import json
+from unittest.mock import patch
+from meta_ads_mcp.core.ads import create_ad_creative
+
+
+def _mock_page_discovery():
+    return patch(
+        "meta_ads_mcp.core.ads._discover_pages_for_account",
+        return_value={"success": True, "page_id": "p", "page_name": "T"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_warning_when_asset_feed_spec_missing_on_readback():
+    collapsed_readback = {
+        "id": "c1",
+        "object_story_spec": {"page_id": "p", "link_data": {"image_hash": "h1", "link": "https://ex.com"}},
+    }
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, _mock_page_discovery():
+        mock_api.side_effect = [{"id": "c1"}, collapsed_readback]
+        result_json = await create_ad_creative(
+            account_id="act_1",
+            page_id="p",
+            link_url="https://ex.com",
+            image_hashes=["h1", "h2"],
+            asset_customization_rules=[
+                {"placement_groups": ["FEED"], "customization_spec": {"image_hashes": ["h1"]}},
+                {"placement_groups": ["STORY"], "customization_spec": {"image_hashes": ["h2"]}},
+            ],
+            headline="Hi",
+            description="Desc",
+            message="Msg",
+            call_to_action_type="SHOP_NOW",
+            access_token="tok",
+        )
+        result = json.loads(result_json)
+        posted = mock_api.call_args_list[0][0][2]
+        assert len(posted["asset_feed_spec"]["images"]) == 2
+        assert posted["asset_feed_spec"]["asset_customization_rules"]
+        warning = result.get("warning")
+        assert warning is not None
+        warn_text = warning if isinstance(warning, str) else " ".join(warning)
+        assert "silently rewrote" in warn_text
+        assert "is_dynamic_creative" in warn_text
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_asset_feed_spec_preserved():
+    preserved_readback = {
+        "id": "c2",
+        "object_story_spec": {"page_id": "p"},
+        "asset_feed_spec": {
+            "images": [{"hash": "h1"}, {"hash": "h2"}],
+            "asset_customization_rules": [{"customization_spec": {"publisher_platforms": ["facebook"]}}],
+            "optimization_type": "PLACEMENT",
+        },
+    }
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, _mock_page_discovery():
+        mock_api.side_effect = [{"id": "c2"}, preserved_readback]
+        result_json = await create_ad_creative(
+            account_id="act_1",
+            page_id="p",
+            link_url="https://ex.com",
+            image_hashes=["h1", "h2"],
+            asset_customization_rules=[
+                {"placement_groups": ["FEED"], "customization_spec": {"image_hashes": ["h1"]}},
+                {"placement_groups": ["STORY"], "customization_spec": {"image_hashes": ["h2"]}},
+            ],
+            headline="Hi",
+            description="Desc",
+            message="Msg",
+            access_token="tok",
+        )
+        result = json.loads(result_json)
+        warning = result.get("warning")
+        warn_text = "" if warning is None else (warning if isinstance(warning, str) else " ".join(warning))
+        assert "silently rewrote" not in warn_text
+
+
+@pytest.mark.asyncio
+async def test_dof_downgrade_warning_revised():
+    preserved_readback = {
+        "id": "c3",
+        "object_story_spec": {"page_id": "p"},
+        "asset_feed_spec": {
+            "images": [{"hash": "h1"}, {"hash": "h2"}],
+            "asset_customization_rules": [{"customization_spec": {}}],
+        },
+    }
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api, _mock_page_discovery():
+        mock_api.side_effect = [{"id": "c3"}, preserved_readback]
+        result_json = await create_ad_creative(
+            account_id="act_1",
+            page_id="p",
+            link_url="https://ex.com",
+            image_hashes=["h1", "h2"],
+            asset_customization_rules=[
+                {"placement_groups": ["FEED"], "customization_spec": {"image_hashes": ["h1"]}},
+                {"placement_groups": ["STORY"], "customization_spec": {"image_hashes": ["h2"]}},
+            ],
+            optimization_type="DEGREES_OF_FREEDOM",
+            headline="Hi",
+            description="Desc",
+            message="Msg",
+            access_token="tok",
+        )
+        result = json.loads(result_json)
+        warning = result.get("warning")
+        assert warning is not None
+        warn_text = warning if isinstance(warning, str) else " ".join(warning)
+        assert "placement-specific images are respected" not in warn_text
+        assert "is_dynamic_creative" in warn_text


### PR DESCRIPTION
## Summary

- When create_ad_creative posts multi-image asset_feed_spec with asset_customization_rules, Meta can accept the POST and return a creative id without error, yet persist only a single-image object_story_spec. The handler now compares the readback against the posted payload and surfaces a warning when the multi-image feed was not preserved.
- Revises the DOF downgrade warning to stop claiming placement rules always take effect; instead points to the is_dynamic_creative dependency.
- Adds pytest cases covering the collapsed, preserved, and DOF-downgrade paths.
- Bumps version to 1.0.88 (pyproject.toml + server.json).

## Test plan

- [x] pytest tests/test_create_ad_creative_collapse_warning.py (new) — 3 tests
- [x] pytest tests/test_create_ad_creative_simple.py — still green
- [x] pytest tests/test_dynamic_creatives.py — still green