### PR TITLE
fix(ads): reuse existing video adlabel in placement_groups rules

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -216,12 +216,25 @@ def _translate_video_customization_rules(
 
     Also tolerates `customization_spec.video_label: "str"` (string) by hoisting it to
     `video_label: {"name": "str"}` at the rule level. Existing adlabels on
-    videos_array entries (e.g., user-supplied via `videos[].label`) are preserved.
+    videos_array entries (e.g., user-supplied via `videos[].label`) are preserved,
+    and the rule's video_label reuses that existing adlabel name so the rule points
+    at the asset the caller labeled (Meta rejects the creative with error_subcode
+    2446173 "Target rule label ... doesn't refer to any of the asset labels" if
+    the rule references a label that isn't on any asset).
 
     Rules that do NOT contain placement_groups are passed through unchanged.
     """
     if not rules or not any("placement_groups" in r for r in rules):
         return rules, videos_array
+
+    existing_vid_to_label: Dict[str, str] = {}
+    for v in videos_array:
+        vid_id = str(v.get("video_id", ""))
+        adlabels = v.get("adlabels")
+        if vid_id and vid_id not in existing_vid_to_label and isinstance(adlabels, list) and adlabels:
+            first = adlabels[0]
+            if isinstance(first, dict) and isinstance(first.get("name"), str):
+                existing_vid_to_label[vid_id] = first["name"]
 
     vid_to_label: Dict[str, str] = {}
     label_counter = 0
@@ -266,16 +279,22 @@ def _translate_video_customization_rules(
         translated_rule: Dict[str, Any] = {"customization_spec": meta_cspec}
 
         # Assign video_label at the rule level. Precedence:
-        #   1) customization_spec.video_ids: [id] — map id → generated label
+        #   1) customization_spec.video_ids: [id] — map id → label. Reuse the
+        #      explicit adlabel already on the matching videos_array entry (from
+        #      videos[].label) so rule labels match asset labels; otherwise mint
+        #      a PBOARD_VID_N and stamp it on the video.
         #   2) customization_spec.video_label: "str" — coerce string to {"name": str}
         #   3) customization_spec.video_label: {"name": "str"} — pass through
         vid_ids = cspec_input.get("video_ids", [])
         raw_video_label = cspec_input.get("video_label")
         if vid_ids:
-            v = vid_ids[0]
+            v = str(vid_ids[0])
             if v not in vid_to_label:
-                vid_to_label[v] = f"PBOARD_VID_{label_counter}"
-                label_counter += 1
+                if v in existing_vid_to_label:
+                    vid_to_label[v] = existing_vid_to_label[v]
+                else:
+                    vid_to_label[v] = f"PBOARD_VID_{label_counter}"
+                    label_counter += 1
             translated_rule["video_label"] = {"name": vid_to_label[v]}
         elif isinstance(raw_video_label, str):
             translated_rule["video_label"] = {"name": raw_video_label}
@@ -284,9 +303,10 @@ def _translate_video_customization_rules(
 
         translated_rules.append(translated_rule)
 
-    # Add adlabels to videos_array for referenced video_ids. Preserve any adlabels
-    # the caller already set (via `videos[].label` in create_ad_creative), so explicit
-    # labels win over auto-generated ones.
+    # Stamp adlabels onto videos_array entries for video_ids that were referenced
+    # by rules. Only applies to videos without existing adlabels — explicit user
+    # labels (from videos[].label) win, and the rule's video_label was already
+    # aligned to that label above.
     updated_videos: List[Dict[str, Any]] = []
     for v in videos_array:
         vid_id = str(v.get("video_id", ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.88"
+version = "1.0.89"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -770,9 +770,12 @@ def test_translate_video_rules_passthrough_raw_format():
     assert updated_videos == videos_array
 
 
-def test_translate_video_rules_preserves_existing_adlabels():
-    """If videos_array entries already have adlabels, do not override them."""
-    # User-supplied labels via videos[{"label": "my_label"}]
+def test_translate_video_rules_reuses_existing_adlabel():
+    """If videos_array entries already have adlabels (from videos[].label),
+    the rule's video_label must reuse that label name so Meta sees matching
+    asset labels on both sides. Minting PBOARD_VID_N while preserving the
+    user's adlabel triggers error_subcode 2446173 ("Target rule label ...
+    doesn't refer to any of the asset labels")."""
     videos_array = [
         {"video_id": "vidA", "adlabels": [{"name": "user_label"}]},
     ]
@@ -785,10 +788,42 @@ def test_translate_video_rules_preserves_existing_adlabels():
 
     translated, updated_videos = _translate_video_customization_rules(rules, videos_array)
 
-    # video_label at rule level uses auto-generated name
-    assert translated[0]["video_label"] == {"name": "PBOARD_VID_0"}
-    # ...but the existing adlabels on the video are preserved (not overridden)
+    # Rule video_label points at the adlabel the caller set on the video.
+    assert translated[0]["video_label"] == {"name": "user_label"}
+    # Video adlabel is unchanged.
     assert updated_videos[0]["adlabels"] == [{"name": "user_label"}]
+
+
+def test_translate_video_rules_same_video_id_different_labels_uses_first():
+    """Caller passes the same video_id twice with different labels (the ALYNNE
+    repro): videos=[{vid:X,label:L1},{vid:X,label:L2}] +
+    rules=[{FEED,video_ids:[X]},{STORY,video_ids:[X]}].
+
+    Both rules resolve to the first adlabel found for that video_id, producing
+    a payload Meta accepts (rule labels match the asset labels present on the
+    videos). Meta previously rejected this with error_subcode 2446173 because
+    the translator minted PBOARD_VID_0 for the rules but left feed_video /
+    story_video on the videos."""
+    videos_array = [
+        {"video_id": "X", "adlabels": [{"name": "feed_video"}]},
+        {"video_id": "X", "adlabels": [{"name": "story_video"}]},
+    ]
+    rules = [
+        {"placement_groups": ["FEED"], "customization_spec": {"video_ids": ["X"]}},
+        {"placement_groups": ["STORY"], "customization_spec": {"video_ids": ["X"]}},
+    ]
+
+    translated, updated_videos = _translate_video_customization_rules(rules, videos_array)
+
+    assert translated[0]["video_label"] == {"name": "feed_video"}
+    assert translated[1]["video_label"] == {"name": "feed_video"}
+    # Videos retain their explicit labels (Meta sees feed_video + story_video
+    # as valid asset labels, so PBOARD_VID_0 never appears).
+    assert updated_videos[0]["adlabels"] == [{"name": "feed_video"}]
+    assert updated_videos[1]["adlabels"] == [{"name": "story_video"}]
+    # Sanity: no PBOARD_VID_* leaks into the payload.
+    for rule in translated:
+        assert "PBOARD_VID" not in rule["video_label"]["name"]
 
 
 def test_translate_video_rules_string_video_label_coerced():


### PR DESCRIPTION
## Summary

- When `create_ad_creative` is called with `videos[{video_id, label}]` AND `asset_customization_rules` that reference those videos via `video_ids`, the translator now reuses the explicit adlabel as the rule `video_label` instead of minting a fresh `PBOARD_VID_N`.
- Meta rejected the prior mismatch shape with `error_subcode 2446173` (Target rule label does not refer to any of the asset labels), and sometimes with the generic `1487390` (Adcreative Create Failed / Something went wrong).
- Happy path is unchanged: when no explicit adlabels are on the videos, `PBOARD_VID_N` minting still runs and Meta accepts the creative.

## Counter-example evidence from production logs (last 30 days)

| Shape | Outcome |
|---|---|
| videos WITHOUT labels + rules with video_ids | Works — Meta mints PBOARD_VID_N symmetrically (verified on act_1276764704512927 2026-04-16) |
| videos WITH labels + rules with video_ids | Never works — 2446173 or 1487390 (2x failures: one with explicit label mismatch error, one with generic 1487390) |

No production success was ever observed for the broken shape, so the fix is pure bug-fix with no behavior regression risk.

## Stacked on

Branch cuts off nictuku/create-ad-creative-collapse-warning — if that PR is not landed, rebase onto main before merging.

## Test plan

- [x] tests/test_video_creatives.py — 26 tests pass (2 new: test_translate_video_rules_reuses_existing_adlabel, test_translate_video_rules_same_video_id_different_labels_uses_first)
- [x] Full pytest suite (419 tests) ran green via pre-commit hook