### PR TITLE
docs(ads): reword DOF-downgrade warning to name PAC, not is_dynamic_creative

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2465,9 +2465,12 @@ async def create_ad_creative(
             if dof_downgraded:
                 warnings_.append(
                     "optimization_type=DEGREES_OF_FREEDOM was dropped because "
-                    "asset_customization_rules was also provided. Whether placement "
-                    "rules take effect depends on the target ad set's "
-                    "is_dynamic_creative capability."
+                    "asset_customization_rules was also provided (Meta ignores "
+                    "rules under DOF). The creative is stored in Placement-Asset-"
+                    "Customization mode, which routes each asset to its placement "
+                    "via rules and does not require is_dynamic_creative on the "
+                    "ad set. If you wanted Advantage+ auto-optimization across "
+                    "all assets instead, remove asset_customization_rules."
                 )
             elif dof_multi_image_warning:
                 warnings_.append(dof_multi_image_warning)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.89"
+version = "1.0.90"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_create_ad_creative_collapse_warning.py
+++ b/tests/test_create_ad_creative_collapse_warning.py
@@ -112,4 +112,9 @@ async def test_dof_downgrade_warning_revised():
         assert warning is not None
         warn_text = warning if isinstance(warning, str) else " ".join(warning)
         assert "placement-specific images are respected" not in warn_text
-        assert "is_dynamic_creative" in warn_text
+        # The downgrade lands the creative in PAC, which routes by placement
+        # without the ad set's is_dynamic_creative flag. The warning must not
+        # claim rules depend on is_dynamic_creative (they don't — that's the
+        # gate for regular Dynamic Creative, not Placement Asset Customization).
+        assert "depends on" not in warn_text and "take effect depends" not in warn_text
+        assert "Placement" in warn_text or "PLACEMENT" in warn_text


### PR DESCRIPTION
## Summary

The DOF-downgrade warning told callers that placement rules depend on the target ad set is_dynamic_creative flag. That conflates two modes:

- **is_dynamic_creative** governs regular Dynamic Creative.
- **Placement Asset Customization** routes by placement based on rules, without requiring is_dynamic_creative on the ad set.

When asset_customization_rules is set alongside DOF, the handler drops optimization_type and the creative is stored in PAC mode — so is_dynamic_creative is not the right gate to point at. Exercising the deployed tool with a PAC-shaped payload on a static ad set shows the creative persists as expected.

The new wording calls out the mode transition explicitly and suggests removing asset_customization_rules if the caller actually wanted Advantage+ auto-optimization. The collapse-detection warning (the one added in #93) is unchanged.

Bumps version to 1.0.90.

## Test plan

- [x] `pytest tests/test_create_ad_creative_collapse_warning.py tests/test_create_ad_creative_simple.py tests/test_dynamic_creatives.py` — 31 tests green.
- [x] Assertion now requires the warning to say Placement / PAC and not to claim rules depend on anything.
