### PR TITLE
fix(ads): emit call_to_actions plural for lead-form asset_feed_spec creatives

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2053,7 +2053,19 @@ async def create_ad_creative(
                 if link_url:
                     asset_feed_spec_osi["link_urls"] = [{"website_url": link_url}]
                 if call_to_action_type:
-                    asset_feed_spec_osi["call_to_action_types"] = [call_to_action_type]
+                    if lead_gen_form_id or phone_number:
+                        cta_osi_value: Dict[str, Any] = {}
+                        if link_url:
+                            cta_osi_value["link"] = link_url
+                        if lead_gen_form_id:
+                            cta_osi_value["lead_gen_form_id"] = lead_gen_form_id
+                        if phone_number:
+                            cta_osi_value["phone_number"] = phone_number
+                        asset_feed_spec_osi["call_to_actions"] = [
+                            {"type": call_to_action_type, "value": cta_osi_value}
+                        ]
+                    else:
+                        asset_feed_spec_osi["call_to_action_types"] = [call_to_action_type]
                 if asset_feed_spec_osi:
                     creative_data["asset_feed_spec"] = asset_feed_spec_osi
             elif call_to_action_type:
@@ -2213,7 +2225,19 @@ async def create_ad_creative(
 
             # CTA in asset_feed_spec only for non-DOF (DOF puts CTA in link_data)
             if call_to_action_type and not is_dof:
-                asset_feed_spec["call_to_action_types"] = [call_to_action_type]
+                if lead_gen_form_id or phone_number:
+                    cta_value: Dict[str, Any] = {}
+                    if link_url:
+                        cta_value["link"] = link_url
+                    if lead_gen_form_id:
+                        cta_value["lead_gen_form_id"] = lead_gen_form_id
+                    if phone_number:
+                        cta_value["phone_number"] = phone_number
+                    asset_feed_spec["call_to_actions"] = [
+                        {"type": call_to_action_type, "value": cta_value}
+                    ]
+                else:
+                    asset_feed_spec["call_to_action_types"] = [call_to_action_type]
 
             # Add placement-specific asset customization rules if provided
             if asset_customization_rules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.90"
+version = "1.0.91"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -956,6 +956,120 @@ async def test_create_ad_creative_videos_with_placement_rules_sends_correct_payl
         assert story_rule["video_label"] == {"name": "PBOARD_VID_1"}
 
 
+@pytest.mark.asyncio
+async def test_lead_form_with_videos_and_rules_emits_call_to_actions_plural():
+    """Lead-form ads built via asset_feed_spec MUST emit `call_to_actions`
+    (plural object array) carrying value.lead_gen_form_id, not the string-only
+    `call_to_action_types`. Without the plural form, Meta accepts the creative
+    but silently drops the form id, and the downstream create_ad fails with
+    error_subcode 3390001 ("Missing Lead Form").
+
+    Live-verified 2026-04-30 against Sandbox A (act_1276764704512927) — POSTing
+    asset_feed_spec.call_to_actions plural with value.lead_gen_form_id and
+    value.link returned creative 1651066586172582 with the form preserved on
+    readback.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "1050252844829277",
+            "page_name": "Sandbox Page",
+        }
+
+        mock_api.side_effect = [
+            {"picture": "https://example.com/vidA-thumb.jpg"},
+            {"picture": "https://example.com/vidB-thumb.jpg"},
+            {"id": "creative_lead_form"},
+            {"id": "creative_lead_form", "name": "Lead Form Multi-Placement", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_1276764704512927",
+            videos=[
+                {"video_id": "979767987909906", "label": "feed_1x1"},
+                {"video_id": "1603514887420866", "label": "reels_9x16"},
+            ],
+            asset_customization_rules=[
+                {
+                    "customization_spec": {
+                        "publisher_platforms": ["facebook"],
+                        "facebook_positions": ["feed"],
+                    },
+                    "video_label": {"name": "feed_1x1"},
+                },
+                {
+                    "customization_spec": {
+                        "publisher_platforms": ["facebook"],
+                        "facebook_positions": ["story"],
+                    },
+                    "video_label": {"name": "reels_9x16"},
+                },
+            ],
+            name="Lead Form Multi-Placement",
+            link_url="https://www.example.com/lead",
+            call_to_action_type="SIGN_UP",
+            lead_gen_form_id="1022993823609804",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[2][0][2]
+        afs = creative_data["asset_feed_spec"]
+
+        # The plural shape is the ratchet — string-only call_to_action_types
+        # MUST NOT be emitted when a form id is present (would silently drop it).
+        assert "call_to_actions" in afs, (
+            f"Expected call_to_actions plural carrier; got afs keys={list(afs.keys())}"
+        )
+        assert "call_to_action_types" not in afs, (
+            "call_to_action_types (string-only) must not coexist with lead_gen_form_id "
+            "— it is the silent-drop carrier"
+        )
+
+        ctas = afs["call_to_actions"]
+        assert isinstance(ctas, list) and len(ctas) == 1
+        cta = ctas[0]
+        assert cta["type"] == "SIGN_UP"
+        assert cta["value"]["lead_gen_form_id"] == "1022993823609804"
+        assert cta["value"]["link"] == "https://www.example.com/lead"
+
+
+@pytest.mark.asyncio
+async def test_non_lead_cta_keeps_call_to_action_types_string_array():
+    """Regression guard: when there's no lead_gen_form_id and no phone_number,
+    the existing string-only call_to_action_types path stays untouched —
+    don't churn shapes for non-lead creatives.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "1050252844829277",
+            "page_name": "Sandbox Page",
+        }
+        mock_api.side_effect = [
+            {"picture": "https://example.com/thumb.jpg"},
+            {"id": "creative_plain"},
+            {"id": "creative_plain", "name": "Plain Video", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_1276764704512927",
+            videos=[{"video_id": "979767987909906"}],
+            name="Plain Video",
+            link_url="https://www.example.com/",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+        afs = creative_data["asset_feed_spec"]
+        assert afs.get("call_to_action_types") == ["LEARN_MORE"]
+        assert "call_to_actions" not in afs
+
+
 # ---------------------------------------------------------------------------
 # Per-video thumbnail auto-fetch in the videos=[...] branch (PR-B)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When `call_to_action_type` and `lead_gen_form_id` are both set on the `asset_feed_spec` path (multi-video / images / asset_customization_rules / PLACEMENT optimization), Meta's API requires the plural object form `call_to_actions: [{type, value: {lead_gen_form_id, link}}]`. The current code emits the string-only `call_to_action_types: [type]` — Meta silently drops the form, the creative is created with no lead form attached, and the downstream `create_ad` fails with `error_subcode 3390001` ("Missing Lead Form").

This PR routes the CTA through the plural carrier whenever a form id (or phone number) is present, on both the videos/images branch and the `object_story_id` (existing-post) branch.

## E2E proof

- POST via local stack (Python on :9000, Next.js on :4000) using the bug's exact payload (videos + asset_customization_rules + PLACEMENT + lead_gen_form_id) → creative `1642596550329140` minted on Sandbox A.
- Direct Graph readback: `asset_feed_spec.call_to_actions[0].value.lead_gen_form_id = "1022993823609804"` ✓ (with the old code, this field was `null`).
- Schema + fixture pinned in pipeboard.co `tests/api_contracts/meta-ads/ad_creative.schema.json` + `fixtures/create_ad_creative/cta-plural-lead-form-success-readback-2026-04-30.json` (separate PR).

## Test plan

- [x] `tests/test_video_creatives.py` — 28/28 (2 new: lead-form-with-rules emits plural + non-lead keeps string array)
- [x] Full creative suite — 108/108 (test_video_creatives + test_flex_creatives + test_dynamic_creatives + test_create_ad_creative_simple + test_create_ad_creative_collapse_warning + test_object_story_id + test_ad_formats_flexible + test_reminder_ads)
- [x] E2E live probe via local stack against Sandbox A — readback confirms form id preserved
- [ ] Release 1.0.91 to PyPI + roll out to mcp1/mcp2 after merge