### PR TITLE
fix(ads): accept {text,adlabels} headlines/descriptions/messages and drop pre-flight length guards

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1503,6 +1503,46 @@ async def compute_image_crops(
     return json.dumps(result, indent=2)
 
 
+def _normalize_text_variants(items: Optional[List[Any]]) -> Optional[List[Dict[str, Any]]]:
+    """Normalize headlines/descriptions/messages entries into asset_feed_spec text variants.
+
+    Each entry can be either a plain string or a dict like
+    ``{"text": "...", "adlabels": [{"name": "..."}]}`` — the dict form is
+    required when ``asset_customization_rules`` references this variant via
+    ``title_label`` / ``body_label`` / ``description_label``. Without per-entry
+    adlabels, Meta rejects multi-headline + placement-customization creatives
+    with error_subcode 1885878 ("Multiple titles assets can not be applied to
+    rule #1") or 2446173 ("Target rule label doesn't refer to any of the
+    asset labels"). Verified live 2026-04-30 against act_1276764704512927:
+    asset_feed_spec.titles with per-entry adlabels + asset_customization_rules
+    with title_label is accepted by Meta and stored verbatim.
+
+    Returns None if items is None/empty (caller decides whether to skip).
+    """
+    if not items:
+        return None
+    out: List[Dict[str, Any]] = []
+    for entry in items:
+        if isinstance(entry, str):
+            out.append({"text": entry})
+        elif isinstance(entry, dict):
+            text = entry.get("text")
+            if not isinstance(text, str):
+                # Pass through whatever shape Meta gets — let Meta reject it
+                # with its own error if invalid (no preflight validation rule).
+                out.append({k: v for k, v in entry.items()})
+                continue
+            variant: Dict[str, Any] = {"text": text}
+            adlabels = entry.get("adlabels")
+            if adlabels:
+                variant["adlabels"] = adlabels
+            out.append(variant)
+        else:
+            # Unexpected shape — pass through as-is, Meta will return a clear error.
+            out.append(entry)  # type: ignore[arg-type]
+    return out
+
+
 async def _fetch_video_thumbnail(vid_id: str, access_token: str) -> Optional[str]:
     """Fetch a thumbnail URL for a Meta video. Returns None on any failure.
 
@@ -1532,11 +1572,11 @@ async def create_ad_creative(
     page_id: Optional[Union[str, int]] = None,
     link_url: Optional[str] = None,
     message: Optional[str] = None,
-    messages: Optional[List[str]] = None,
+    messages: Optional[List[Union[str, Dict[str, Any]]]] = None,
     headline: Optional[str] = None,
-    headlines: Optional[List[str]] = None,
+    headlines: Optional[List[Union[str, Dict[str, Any]]]] = None,
     description: Optional[str] = None,
-    descriptions: Optional[List[str]] = None,
+    descriptions: Optional[List[Union[str, Dict[str, Any]]]] = None,
     image_hashes: Optional[List[str]] = None,
     video_id: Optional[Union[str, int]] = None,
     thumbnail_url: Optional[str] = None,
@@ -1590,11 +1630,18 @@ async def create_ad_creative(
                  demands one be present on the creative. Pass any valid URL in that case
                  (e.g. the Facebook page URL or your site root).
         message: Single ad copy/text (cannot be used with messages)
-        messages: List of primary text variants for multi-variant copy testing (cannot be used with message)
+        messages: List of primary text variants for multi-variant copy testing (cannot be used with message).
+                  Each entry can be a plain string, OR a dict {"text": "...", "adlabels": [{"name": "..."}]}
+                  when used with asset_customization_rules that reference body_label.
         headline: Single headline for simple ads (cannot be used with headlines)
-        headlines: List of headline variants for multi-variant copy testing (cannot be used with headline)
+        headlines: List of headline variants for multi-variant copy testing (cannot be used with headline).
+                  Each entry can be a plain string, OR a dict {"text": "...", "adlabels": [{"name": "..."}]}
+                  when used with asset_customization_rules that reference title_label.
+                  Meta enforces the actual length limit; do not pre-truncate.
         description: Single description for simple ads (cannot be used with descriptions)
-        descriptions: List of description variants for multi-variant copy testing (cannot be used with description)
+        descriptions: List of description variants for multi-variant copy testing (cannot be used with description).
+                  Each entry can be a plain string, OR a dict {"text": "...", "adlabels": [{"name": "..."}]}
+                  when used with asset_customization_rules that reference description_label.
         image_hashes: List of image hashes for FLEX creatives (up to 10, cannot be used with image_hash or video_id).
                      IMPORTANT: When optimization_type="DEGREES_OF_FREEDOM" (FLEX/Advantage+ mode),
                      only ONE image is served at delivery time regardless of how many hashes you provide.
@@ -1960,20 +2007,10 @@ async def create_ad_creative(
     if description and descriptions:
         return json.dumps({"error": "Cannot specify both 'description' and 'descriptions'. Use 'description' for single description or 'descriptions' for multiple."}, indent=2)
     
-    # Validate dynamic creative parameters (plural forms only)
-    if headlines:
-        if len(headlines) > 5:
-            return json.dumps({"error": "Maximum 5 headlines allowed for dynamic creatives"}, indent=2)
-        for i, h in enumerate(headlines):
-            if len(h) > 40:
-                return json.dumps({"error": f"Headline {i+1} exceeds 40 character limit"}, indent=2)
-
-    if descriptions:
-        if len(descriptions) > 5:
-            return json.dumps({"error": "Maximum 5 descriptions allowed for dynamic creatives"}, indent=2)
-        for i, d in enumerate(descriptions):
-            if len(d) > 125:
-                return json.dumps({"error": f"Description {i+1} exceeds 125 character limit"}, indent=2)
+    # No client-side length / count guards on headlines / descriptions / messages.
+    # Meta enforces its own limits and returns clear errors; pre-flight guards reject
+    # strings the Meta UI accepts (e.g. 41-char headlines verified live 2026-04-30
+    # against act_1276764704512927 — Meta returned 200 and stored the title verbatim).
 
     # Prepare the API endpoint for creating a creative
     endpoint = f"{account_id}/adcreatives"
@@ -2203,23 +2240,23 @@ async def create_ad_creative(
             if images_array:
                 asset_feed_spec["images"] = images_array
 
-            # Handle headlines - Meta API uses "titles" not "headlines" in asset_feed_spec
-            # Auto-promote singular headline to single-element array when in asset_feed_spec path
+            # Handle headlines - Meta API uses "titles" not "headlines" in asset_feed_spec.
+            # Each entry can be a plain string OR {"text": ..., "adlabels": [...]}, the latter
+            # required when asset_customization_rules references title_label.
             if headlines:
-                asset_feed_spec["titles"] = [{"text": headline_text} for headline_text in headlines]
+                asset_feed_spec["titles"] = _normalize_text_variants(headlines)
             elif headline:
                 asset_feed_spec["titles"] = [{"text": headline}]
 
-            # Handle descriptions
-            # Auto-promote singular description to single-element array when in asset_feed_spec path
+            # Handle descriptions (same dual-shape support).
             if descriptions:
-                asset_feed_spec["descriptions"] = [{"text": description_text} for description_text in descriptions]
+                asset_feed_spec["descriptions"] = _normalize_text_variants(descriptions)
             elif description:
                 asset_feed_spec["descriptions"] = [{"text": description}]
 
-            # Handle bodies: messages (plural) or message (singular)
+            # Handle bodies: messages (plural, dual-shape) or message (singular).
             if messages:
-                asset_feed_spec["bodies"] = [{"text": m} for m in messages]
+                asset_feed_spec["bodies"] = _normalize_text_variants(messages)
             elif message:
                 asset_feed_spec["bodies"] = [{"text": message}]
 
@@ -2543,11 +2580,11 @@ async def update_ad_creative(
     access_token: Optional[str] = None,
     name: Optional[str] = None,
     message: Optional[str] = None,
-    messages: Optional[List[str]] = None,
+    messages: Optional[List[Union[str, Dict[str, Any]]]] = None,
     headline: Optional[str] = None,
-    headlines: Optional[List[str]] = None,
+    headlines: Optional[List[Union[str, Dict[str, Any]]]] = None,
     description: Optional[str] = None,
-    descriptions: Optional[List[str]] = None,
+    descriptions: Optional[List[Union[str, Dict[str, Any]]]] = None,
     optimization_type: Optional[str] = None,
     dynamic_creative_spec: Optional[Dict[str, Any]] = None,
     call_to_action_type: Optional[str] = None,
@@ -2609,20 +2646,8 @@ async def update_ad_creative(
     if optimization_type and optimization_type != "DEGREES_OF_FREEDOM":
         return json.dumps({"error": f"Invalid optimization_type '{optimization_type}'. Only 'DEGREES_OF_FREEDOM' is supported."}, indent=2)
 
-    # Validate dynamic creative parameters (plural forms only)
-    if headlines:
-        if len(headlines) > 5:
-            return json.dumps({"error": "Maximum 5 headlines allowed for dynamic creatives"}, indent=2)
-        for i, h in enumerate(headlines):
-            if len(h) > 40:
-                return json.dumps({"error": f"Headline {i+1} exceeds 40 character limit"}, indent=2)
-
-    if descriptions:
-        if len(descriptions) > 5:
-            return json.dumps({"error": "Maximum 5 descriptions allowed for dynamic creatives"}, indent=2)
-        for i, d in enumerate(descriptions):
-            if len(d) > 125:
-                return json.dumps({"error": f"Description {i+1} exceeds 125 character limit"}, indent=2)
+    # No client-side length / count guards on headlines / descriptions / messages —
+    # see the matching note in create_ad_creative; Meta enforces its own limits.
 
     # Prepare the update data
     update_data = {}
@@ -2651,23 +2676,21 @@ async def update_ad_creative(
         if optimization_type:
             asset_feed_spec["optimization_type"] = optimization_type
 
-        # Handle headlines - Meta API uses "titles" not "headlines" in asset_feed_spec
-        # Auto-promote singular headline to single-element array when in asset_feed_spec path
+        # Handle headlines/descriptions/bodies — each entry can be a plain string
+        # OR {"text": ..., "adlabels": [...]}, the latter required when
+        # asset_customization_rules references title_label/body_label/description_label.
         if headlines:
-            asset_feed_spec["titles"] = [{"text": headline_text} for headline_text in headlines]
+            asset_feed_spec["titles"] = _normalize_text_variants(headlines)
         elif headline:
             asset_feed_spec["titles"] = [{"text": headline}]
 
-        # Handle descriptions
-        # Auto-promote singular description to single-element array when in asset_feed_spec path
         if descriptions:
-            asset_feed_spec["descriptions"] = [{"text": description_text} for description_text in descriptions]
+            asset_feed_spec["descriptions"] = _normalize_text_variants(descriptions)
         elif description:
             asset_feed_spec["descriptions"] = [{"text": description}]
 
-        # Handle bodies: messages (plural) or message (singular)
         if messages:
-            asset_feed_spec["bodies"] = [{"text": m} for m in messages]
+            asset_feed_spec["bodies"] = _normalize_text_variants(messages)
         elif message:
             asset_feed_spec["bodies"] = [{"text": message}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.91"
+version = "1.0.92"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_dynamic_creatives.py
+++ b/tests/test_dynamic_creatives.py
@@ -335,57 +335,51 @@ class TestDynamicCreatives:
             assert "descriptions" in creative_data["asset_feed_spec"]
             assert "dynamic_creative_spec" in creative_data
     
-    async def test_create_ad_creative_validation_max_headlines(self):
-        """Test validation for maximum number of headlines."""
-        
-        # Create list with more than 5 headlines (assuming 5 is the limit)
-        too_many_headlines = [f"Headline {i}" for i in range(6)]
-        
-        result = await create_ad_creative(
-            access_token="test_token",
-            account_id="act_123456789",
-            name="Test Creative",
-            image_hash="abc123",
-            page_id="987654321",
-            link_url="https://example.com",
-            headlines=too_many_headlines
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "maximum" in error_data["error"].lower() or "limit" in error_data["error"].lower()
-        else:
-            assert "error" in result_data
-            assert "maximum" in result_data["error"].lower() or "limit" in result_data["error"].lower()
-    
-    async def test_create_ad_creative_validation_max_descriptions(self):
-        """Test validation for maximum number of descriptions."""
-        
-        # Create list with more than 5 descriptions (assuming 5 is the limit)
-        too_many_descriptions = [f"Description {i}" for i in range(6)]
-        
-        result = await create_ad_creative(
-            access_token="test_token",
-            account_id="act_123456789",
-            name="Test Creative",
-            image_hash="abc123",
-            page_id="987654321",
-            link_url="https://example.com",
-            descriptions=too_many_descriptions
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "maximum" in error_data["error"].lower() or "limit" in error_data["error"].lower()
-        else:
-            assert "error" in result_data
-            assert "maximum" in result_data["error"].lower() or "limit" in result_data["error"].lower()
+    async def test_create_ad_creative_no_preflight_count_limit_on_headlines(self):
+        """create_ad_creative no longer rejects >5 headlines client-side.
+
+        Meta enforces its own limit; pre-flight guards block payloads that the
+        Meta UI accepts (verified live 2026-04-30 against act_1276764704512927).
+        Per feedback_no_preflight_validation: never strip/filter user-provided
+        params before sending to Meta.
+        """
+        many_headlines = [f"Headline {i}" for i in range(6)]
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "creative_many_h"}
+            result = await create_ad_creative(
+                access_token="test_token",
+                account_id="act_123456789",
+                name="Test Creative",
+                image_hash="abc123",
+                page_id="987654321",
+                link_url="https://example.com",
+                headlines=many_headlines,
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            creative_data = mock_api.call_args_list[0][0][2]
+            titles = creative_data["asset_feed_spec"]["titles"]
+            assert [t["text"] for t in titles] == many_headlines
+
+    async def test_create_ad_creative_no_preflight_count_limit_on_descriptions(self):
+        """create_ad_creative no longer rejects >5 descriptions client-side."""
+        many_descriptions = [f"Description {i}" for i in range(6)]
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "creative_many_d"}
+            result = await create_ad_creative(
+                access_token="test_token",
+                account_id="act_123456789",
+                name="Test Creative",
+                image_hash="abc123",
+                page_id="987654321",
+                link_url="https://example.com",
+                descriptions=many_descriptions,
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            creative_data = mock_api.call_args_list[0][0][2]
+            descs = creative_data["asset_feed_spec"]["descriptions"]
+            assert [d["text"] for d in descs] == many_descriptions
     
 
     
@@ -562,93 +556,72 @@ class TestDynamicCreatives:
             assert "error" in result_data
             assert "Cannot specify both 'description' and 'descriptions'" in result_data["error"]
 
-    async def test_update_ad_creative_validation_max_headlines(self):
-        """Test validation for maximum number of headlines in update."""
-        
-        # Create list with more than 5 headlines (limit)
-        too_many_headlines = [f"Headline {i}" for i in range(6)]
-        
-        result = await update_ad_creative(
-            access_token="test_token",
-            creative_id="123456789",
-            headlines=too_many_headlines
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "maximum 5 headlines" in error_data["error"].lower()
-        else:
-            assert "error" in result_data
-            assert "maximum 5 headlines" in result_data["error"].lower()
-    
-    async def test_update_ad_creative_validation_max_descriptions(self):
-        """Test validation for maximum number of descriptions in update."""
-        
-        # Create list with more than 5 descriptions (limit)
-        too_many_descriptions = [f"Description {i}" for i in range(6)]
-        
-        result = await update_ad_creative(
-            access_token="test_token",
-            creative_id="123456789",
-            descriptions=too_many_descriptions
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "maximum 5 descriptions" in error_data["error"].lower()
-        else:
-            assert "error" in result_data
-            assert "maximum 5 descriptions" in result_data["error"].lower()
-    
-    async def test_update_ad_creative_validation_headline_length(self):
-        """Test validation for headline character limit."""
-        
-        # Create headline longer than 40 characters
-        long_headline = "A" * 41
-        
-        result = await update_ad_creative(
-            access_token="test_token",
-            creative_id="123456789",
-            headlines=[long_headline]
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "40 character limit" in error_data["error"]
-        else:
-            assert "error" in result_data
-            assert "40 character limit" in result_data["error"]
-    
-    async def test_update_ad_creative_validation_description_length(self):
-        """Test validation for description character limit."""
-        
-        # Create description longer than 125 characters
+    async def test_update_ad_creative_no_preflight_count_limit_on_headlines(self):
+        """update_ad_creative no longer rejects >5 headlines client-side."""
+        many_headlines = [f"Headline {i}" for i in range(6)]
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "123456789"}
+            result = await update_ad_creative(
+                access_token="test_token",
+                creative_id="123456789",
+                headlines=many_headlines,
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            update_data = mock_api.call_args_list[0][0][2]
+            titles = update_data["asset_feed_spec"]["titles"]
+            assert [t["text"] for t in titles] == many_headlines
+
+    async def test_update_ad_creative_no_preflight_count_limit_on_descriptions(self):
+        """update_ad_creative no longer rejects >5 descriptions client-side."""
+        many_descriptions = [f"Description {i}" for i in range(6)]
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "123456789"}
+            result = await update_ad_creative(
+                access_token="test_token",
+                creative_id="123456789",
+                descriptions=many_descriptions,
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            update_data = mock_api.call_args_list[0][0][2]
+            descs = update_data["asset_feed_spec"]["descriptions"]
+            assert [d["text"] for d in descs] == many_descriptions
+
+    async def test_update_ad_creative_no_preflight_headline_length_limit(self):
+        """update_ad_creative no longer rejects 41+ char headlines client-side.
+
+        Verified live 2026-04-30 against act_1276764704512927 — Meta accepted
+        and stored a 41-char headline ("21% BTW cadeau op hordeuren en raamhorren")
+        verbatim. Pre-flight guards reject strings the Meta UI accepts.
+        """
+        long_headline = "21% BTW cadeau op hordeuren en raamhorren"  # 41 chars
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "123456789"}
+            result = await update_ad_creative(
+                access_token="test_token",
+                creative_id="123456789",
+                headlines=[long_headline],
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            update_data = mock_api.call_args_list[0][0][2]
+            assert update_data["asset_feed_spec"]["titles"] == [{"text": long_headline}]
+
+    async def test_update_ad_creative_no_preflight_description_length_limit(self):
+        """update_ad_creative no longer rejects 126+ char descriptions client-side."""
         long_description = "A" * 126
-        
-        result = await update_ad_creative(
-            access_token="test_token",
-            creative_id="123456789",
-            descriptions=[long_description]
-        )
-        
-        result_data = json.loads(result)
-        # The error might be wrapped in a 'data' field
-        if "data" in result_data:
-            error_data = json.loads(result_data["data"])
-            assert "error" in error_data
-            assert "125 character limit" in error_data["error"]
-        else:
-            assert "error" in result_data
-            assert "125 character limit" in result_data["error"]
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "123456789"}
+            result = await update_ad_creative(
+                access_token="test_token",
+                creative_id="123456789",
+                descriptions=[long_description],
+            )
+            result_data = json.loads(result)
+            assert result_data.get("success") is True
+            update_data = mock_api.call_args_list[0][0][2]
+            assert update_data["asset_feed_spec"]["descriptions"] == [{"text": long_description}]
     
     async def test_update_ad_creative_name_only(self):
         """Test updating just the creative name."""
@@ -859,3 +832,85 @@ class TestDynamicCreatives:
                 assert "details" in result_data
                 assert "update_data_sent" in result_data
  
+    async def test_create_ad_creative_headlines_dict_form_carries_adlabels(self):
+        """Tim/designated.nl 2026-04-30: headlines[] dict form with adlabels.
+
+        Multi-headline + asset_customization_rules requires per-title adlabels
+        + matching title_label on the rule. Without dict-form support, callers
+        get Meta error 1885878 (Multiple titles assets can not be applied to
+        rule) or 2446173 (Target rule label doesn't refer to any of the asset
+        labels). Verified live 2026-04-30 against act_1276764704512927 — the
+        full dict-form shape is accepted and stored verbatim.
+        """
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "creative_dict_titles"}
+            await create_ad_creative(
+                access_token="test_token",
+                account_id="act_123456789",
+                name="Multi-headline placement",
+                image_hash="abc123",
+                page_id="987654321",
+                link_url="https://example.com",
+                headlines=[
+                    {"text": "Feed headline A", "adlabels": [{"name": "feed_title"}]},
+                    {"text": "Feed headline B", "adlabels": [{"name": "feed_title"}]},
+                    {"text": "Story headline A", "adlabels": [{"name": "story_title"}]},
+                ],
+            )
+            creative_data = mock_api.call_args_list[0][0][2]
+            titles = creative_data["asset_feed_spec"]["titles"]
+            assert titles == [
+                {"text": "Feed headline A", "adlabels": [{"name": "feed_title"}]},
+                {"text": "Feed headline B", "adlabels": [{"name": "feed_title"}]},
+                {"text": "Story headline A", "adlabels": [{"name": "story_title"}]},
+            ]
+
+    async def test_create_ad_creative_headlines_mixed_str_and_dict(self):
+        """headlines[] entries may be a mix of plain strings and dict objects."""
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "creative_mixed"}
+            await create_ad_creative(
+                access_token="test_token",
+                account_id="act_123456789",
+                name="Mixed",
+                image_hash="abc123",
+                page_id="987654321",
+                link_url="https://example.com",
+                headlines=[
+                    "Plain headline 1",
+                    {"text": "Tagged headline", "adlabels": [{"name": "story_title"}]},
+                    "Plain headline 2",
+                ],
+            )
+            creative_data = mock_api.call_args_list[0][0][2]
+            assert creative_data["asset_feed_spec"]["titles"] == [
+                {"text": "Plain headline 1"},
+                {"text": "Tagged headline", "adlabels": [{"name": "story_title"}]},
+                {"text": "Plain headline 2"},
+            ]
+
+    async def test_create_ad_creative_descriptions_and_messages_dict_form(self):
+        """descriptions[] and messages[] mirror the same dual-shape support."""
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"id": "creative_dict_dm"}
+            await create_ad_creative(
+                access_token="test_token",
+                account_id="act_123456789",
+                name="Dict desc + body",
+                image_hash="abc123",
+                page_id="987654321",
+                link_url="https://example.com",
+                descriptions=[
+                    {"text": "Feed desc", "adlabels": [{"name": "feed_desc"}]},
+                ],
+                messages=[
+                    {"text": "Feed body", "adlabels": [{"name": "feed_body"}]},
+                ],
+            )
+            creative_data = mock_api.call_args_list[0][0][2]
+            assert creative_data["asset_feed_spec"]["descriptions"] == [
+                {"text": "Feed desc", "adlabels": [{"name": "feed_desc"}]}
+            ]
+            assert creative_data["asset_feed_spec"]["bodies"] == [
+                {"text": "Feed body", "adlabels": [{"name": "feed_body"}]}
+            ]


### PR DESCRIPTION
## Summary

Two related fixes for create_ad_creative and update_ad_creative when used with asset_customization_rules. Addresses two issues from Tim/designated.nl feedback 88f0725f-66f2-462e-8e28-c40220faacba (2026-04-21), task n_db34a421.

### Issue 1 — Multi-headline + placement customization (BLOCKER)

`headlines`, `descriptions`, and `messages` now accept either plain strings (existing behavior) OR objects `{text, adlabels:[{name}]}`, mirroring what `videos[]` / `images[]` already support. The dict form is required when rules reference `title_label` / `body_label` / `description_label` — without per-entry adlabels, Meta rejects with subcode 1885878 ("Multiple titles assets can not be applied to rule") or 2446173 ("Target rule label doesn't refer to any of the asset labels").

A new `_normalize_text_variants` helper handles both shapes; threading wired through both the create branch and the update branch of `asset_feed_spec`.

### Issue 2 — 40-char headline / 125-char description / 5-headline-max guards removed

Removed the four client-side guards. Per `feedback_no_preflight_validation`: never strip or filter user-provided params before sending to Meta. The Meta UI accepts strings the guard rejected — verified live 2026-04-30 against `act_1276764704512927` that the 41-char string `"21% BTW cadeau op hordeuren en raamhorren"` (Tim's exact rejected payload) returns 200 OK and is stored verbatim by Meta.

## E2E proof (local stack: Python 1.0.92 on :9000 + Next.js dev :4000)

- **Issue 2** — `pipeboard mcp tools-call --tool create_ad_creative` with the 41-char "21% BTW cadeau..." headline → creative `1860307394632843` minted, no rejection.
- **Issue 1** — same path, 3 dict-form headlines (`feed_title` x2, `story_title` x1) + 2 `asset_customization_rules` referencing those `title_label`s + 2 placement-labeled videos → creative `849250520845789` minted. Direct Graph readback confirms `asset_feed_spec.titles` carries adlabels per entry and rules' `title_label` resolves to the matching label ids — Meta accepted the multi-headline + rules combination cleanly.

## Test plan

- [x] `tests/test_dynamic_creatives.py` — 32 (was 28; +4 dict-form/mixed/desc-body tests; 6 length/count guard tests inverted to assert pass-through)
- [x] Full creative suite — 111/111 (test_dynamic_creatives + test_video_creatives + test_flex_creatives + test_create_ad_creative_simple + test_create_ad_creative_collapse_warning + test_object_story_id + test_ad_formats_flexible + test_reminder_ads)
- [x] E2E live probe via local stack against Sandbox A — both issues confirmed resolved, multi-headline preserved with adlabels on readback
- [ ] Release 1.0.92 to PyPI + roll out to mcp1/mcp2 after merge