### PR TITLE
feat(duplicate_creative): add new_creative_features_spec override param

### DIFF
--- a/meta_ads_mcp/core/duplication.py
+++ b/meta_ads_mcp/core/duplication.py
@@ -185,6 +185,7 @@ if ENABLE_DUPLICATION:
         new_description: Optional[str] = None,
         new_cta_type: Optional[str] = None,
         new_destination_url: Optional[str] = None,
+        new_creative_features_spec: Optional[Dict[str, Any]] = None,
         pb_token: Optional[str] = None
     ) -> str:
         """
@@ -200,7 +201,25 @@ if ENABLE_DUPLICATION:
             new_description: Override the description for the new creative
             new_cta_type: Override the call-to-action type for the new creative
             new_destination_url: Override the destination URL for the new creative
+            new_creative_features_spec: Override / merge into the duplicate's
+                degrees_of_freedom_spec.creative_features_spec. Use individual
+                feature keys (e.g. image_touchups, image_uncrop, text_optimizations,
+                video_auto_crop) with {"enroll_status": "OPT_IN" | "OPT_OUT"} values.
+                Merged on top of the source creative's surviving creative_features_spec
+                entries. NOTE: the legacy "standard_enhancements" key is rejected by
+                Meta on POST (error_subcode 3858504); pass individual feature keys
+                instead. The duplication response surfaces a warning when the source
+                had standard_enhancements so callers know what to set here.
         """
+        # JSON-string fallback for clients that pass dicts as strings
+        if isinstance(new_creative_features_spec, str):
+            try:
+                _parsed_cfs = json.loads(new_creative_features_spec)
+                if isinstance(_parsed_cfs, dict):
+                    new_creative_features_spec = _parsed_cfs
+            except (json.JSONDecodeError, TypeError):
+                pass
+
         return await _forward_duplication_request(
             "creative",
             creative_id,
@@ -212,6 +231,7 @@ if ENABLE_DUPLICATION:
                 "new_description": new_description,
                 "new_cta_type": new_cta_type,
                 "new_destination_url": new_destination_url,
+                "new_creative_features_spec": new_creative_features_spec,
                 "pb_token": pb_token
             }
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.92"
+version = "1.0.93"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary

Pairs with the pipeboard.co side that hardens duplicate_creative around standard_enhancements stripping (tasks n_db34a421 / n_6e56c2b3 in my-tasks).

When the source creative has the legacy standard_enhancements toggle, Meta rejects it on POST (error_subcode 3858504, re-verified 2026-04-30) and instructs callers to set individual features instead. The pipeboard.co service strips it (mandatory) but now surfaces a structured warning naming what got dropped and what survived. This Python PR adds the actionable counterpart: a new_creative_features_spec param so callers can restore equivalent semantics by setting individual feature keys (image_touchups, image_uncrop, text_optimizations, video_auto_crop, etc) with {enroll_status: OPT_IN | OPT_OUT}.

The override is forwarded to the Next.js service which merges it on top of the source creatives surviving creative_features_spec.

## E2E proof

Local stack (Python on :9000 + Next.js dev :4000):
- Pre-fix: source 26624513227234313 had image_touchups OPT_IN + text_optimizations OPT_IN.
- Duplicate via pipeboard mcp tools-call --tool duplicate_creative with new_creative_features_spec override that flips image_touchups to OPT_OUT and adds image_uncrop OPT_IN.
- Result: duplicate 962587122816028 readback shows image_touchups OPT_OUT (overridden), image_uncrop OPT_IN (added), text_optimizations OPT_IN (preserved). All three keys land in degrees_of_freedom_spec.creative_features_spec exactly as expected.

## Test plan

- [x] Full suite — 440 passed, 9 skipped, 2 deselected
- [x] E2E live probe via local stack against Sandbox A — override merging confirmed verbatim on readback
- [ ] Release 1.0.93 to PyPI + roll out to mcp1/mcp2 after merge