### PR TITLE
fix(insights,accounts): platform_position breakdown + fields on get_account_info

### DIFF
--- a/meta_ads_mcp/core/accounts.py
+++ b/meta_ads_mcp/core/accounts.py
@@ -67,15 +67,32 @@ async def get_ad_accounts(access_token: Optional[str] = None, user_id: str = "me
     return json.dumps(data, indent=2)
 
 
+_DEFAULT_ACCOUNT_INFO_FIELDS = (
+    "id,name,account_id,account_status,amount_spent,balance,currency,age,"
+    "business_city,business_country_code,timezone_name"
+)
+
+
 @mcp_server.tool()
 @meta_api_tool
-async def get_account_info(account_id: str, access_token: Optional[str] = None) -> str:
+async def get_account_info(account_id: str, access_token: Optional[str] = None,
+                           fields: str = "") -> str:
     """
     Get detailed information about a specific ad account.
-    
+
     Args:
         account_id: Meta Ads account ID (format: act_XXXXXXXXX)
         access_token: Meta API access token (optional - will use cached token if not provided)
+        fields: Optional comma-separated Graph API fields to return. When provided,
+                replaces the default field set. Useful for fetching extras like
+                funding_source_details, spend_cap, is_prepay_account, min_daily_budget,
+                disable_reason, capabilities. Default fields:
+                id, name, account_id, account_status, amount_spent, balance, currency,
+                age, business_city, business_country_code, timezone_name.
+                For prepaid accounts (is_prepay_account=true, common in Brazil), the
+                Business Manager "available balance" is the sum of funding_source_details
+                STORED_BALANCE entries plus coupons — the `balance` field alone is the
+                amount due to be billed, not the available pre-paid funds.
     """
     if not account_id:
         return {
@@ -85,13 +102,13 @@ async def get_account_info(account_id: str, access_token: Optional[str] = None) 
                 "example": "Use account_id='act_123456789' or account_id='123456789'"
             }
         }
-    
+
     account_id = ensure_act_prefix(account_id)
-    
+
     # Try to get the account info directly first
     endpoint = f"{account_id}"
     params = {
-        "fields": "id,name,account_id,account_status,amount_spent,balance,currency,age,business_city,business_country_code,timezone_name"
+        "fields": fields.strip() if fields and fields.strip() else _DEFAULT_ACCOUNT_INFO_FIELDS
     }
     
     data = await make_api_request(endpoint, access_token, params)

--- a/meta_ads_mcp/core/insights.py
+++ b/meta_ads_mcp/core/insights.py
@@ -28,6 +28,22 @@ _REDUNDANT_ACTION_PREFIXES = (
 )
 
 
+# Breakdowns Meta rejects when combined with the default action_breakdowns
+# (which is [action_type]). Picking any of these auto-drops the action-typed
+# fields below so the request still succeeds. Meta error path is
+# "(#100) Current combination of data breakdown columns (action_type, X) is invalid".
+_BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE = frozenset({
+    "platform_position",
+})
+
+_ACTION_TYPED_FIELDS = frozenset({
+    "actions",
+    "action_values",
+    "cost_per_action_type",
+    "conversions",
+})
+
+
 def _strip_redundant_actions(row: dict) -> dict:
     """Remove redundant action-type entries from a single insight row."""
     for key in ("actions", "action_values", "cost_per_action_type"):
@@ -71,6 +87,11 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         breakdown: Optional breakdown dimension. Valid values include:
                    Demographic: age, gender, country, region, dma
                    Platform/Device: device_platform, platform_position, publisher_platform, impression_device
+                   NOTE: platform_position is a Meta-restricted breakdown — Meta requires it to be paired
+                   with publisher_platform and is incompatible with the default action_breakdowns=[action_type].
+                   When you pass platform_position, this tool auto-adds publisher_platform and drops the
+                   action-typed fields (actions, action_values, conversions, cost_per_action_type) from the
+                   response. Use publisher_platform alone if you need action data alongside placement.
                    Creative Assets: ad_format_asset, body_asset, call_to_action_asset, description_asset, 
                                   image_asset, link_url_asset, title_asset, video_asset, media_asset_url,
                                   media_creator, media_destination_url, media_format, media_origin_url,
@@ -117,8 +138,28 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         return json.dumps({"error": "No object ID provided. Use object_id, account_id, campaign_id, adset_id, or ad_id."}, indent=2)
         
     endpoint = f"{object_id}/insights"
+    fields = [
+        "account_id", "account_name", "campaign_id", "campaign_name",
+        "adset_id", "adset_name", "ad_id", "ad_name",
+        "impressions", "clicks", "spend", "cpc", "cpm", "ctr", "reach",
+        "frequency", "actions", "action_values", "conversions",
+        "unique_clicks", "cost_per_action_type",
+    ]
+
+    # Meta rejects platform_position alone or with the default
+    # action_breakdowns=[action_type]: it must be paired with publisher_platform,
+    # and the action-typed fields must be dropped. Auto-fix both so the request
+    # succeeds with placement-level metrics.
+    breakdown_values = [b.strip() for b in breakdown.split(",") if b.strip()] if breakdown else []
+    breakdown_set = set(breakdown_values)
+    if "platform_position" in breakdown_set and "publisher_platform" not in breakdown_set:
+        breakdown_values = ["publisher_platform", *breakdown_values]
+        breakdown_set.add("publisher_platform")
+    if breakdown_set & _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE:
+        fields = [f for f in fields if f not in _ACTION_TYPED_FIELDS]
+
     params = {
-        "fields": "account_id,account_name,campaign_id,campaign_name,adset_id,adset_name,ad_id,ad_name,impressions,clicks,spend,cpc,cpm,ctr,reach,frequency,actions,action_values,conversions,unique_clicks,cost_per_action_type",
+        "fields": ",".join(fields),
         "level": level,
         "limit": limit
     }
@@ -134,8 +175,8 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         # Use preset date range
         params["date_preset"] = time_range
     
-    if breakdown:
-        params["breakdowns"] = breakdown
+    if breakdown_values:
+        params["breakdowns"] = ",".join(breakdown_values)
     
     if after:
         params["after"] = after

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.93"
+version = "1.0.94"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- get_insights with breakdown=platform_position used to fail with Meta `(#100) Current combination of data breakdown columns (action_type, platform_position) is invalid`. Auto-prepend `publisher_platform` (Meta requires the pairing) and drop the action-typed fields (`actions`, `action_values`, `conversions`, `cost_per_action_type`) so the request returns placement-level metrics. Docstring documents the constraint.
- get_account_info now accepts an optional `fields` parameter that overrides the default field set, so callers can request `funding_source_details`, `spend_cap`, `is_prepay_account`, etc. — needed for reconciling pre-paid account balances.
- Bump to 1.0.94.

## Test plan
- [x] pytest passes (existing 25 insights + 17 accounts tests, plus full pre-commit suite)
- [x] E2E via pipeboard-cli against local Python on :9000:
  - `breakdown=platform_position` on an account with spend returns placement rows (facebook_reels, facebook_stories, feed, ...) with publisher_platform paired in
  - Same call with empty account succeeds with `data: []` (no error)
  - Regression: no breakdown / `breakdown=publisher_platform` still returns action fields
  - get_account_info with `fields=balance,amount_spent,spend_cap,is_prepay_account,funding_source_details` returns all five
  - get_account_info with no fields returns the unchanged default key set
