### PR TITLE
fix(insights): drop action-typed fields for media_* breakdowns

### DIFF
--- a/.email-allowlist
+++ b/.email-allowlist
@@ -13,3 +13,5 @@ info@pipeboard.co
 # pytest decorator false-positive: @pytest.mark.asyncio matches the email regex
 # because the diff +@pytest.mark.asyncio has + in the character class
 pytest.mark.asyncio
+pytest.fixture
+pytest.mark.parametrize

--- a/.email-allowlist
+++ b/.email-allowlist
@@ -13,5 +13,3 @@ info@pipeboard.co
 # pytest decorator false-positive: @pytest.mark.asyncio matches the email regex
 # because the diff +@pytest.mark.asyncio has + in the character class
 pytest.mark.asyncio
-pytest.fixture
-pytest.mark.parametrize

--- a/meta_ads_mcp/core/insights.py
+++ b/meta_ads_mcp/core/insights.py
@@ -170,7 +170,10 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
     if "platform_position" in breakdown_set and "publisher_platform" not in breakdown_set:
         breakdown_values = ["publisher_platform", *breakdown_values]
         breakdown_set.add("publisher_platform")
-    if breakdown_set & _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE:
+    incompatible_breakdowns = sorted(breakdown_set & _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE)
+    dropped_fields: list[str] = []
+    if incompatible_breakdowns:
+        dropped_fields = [f for f in fields if f in _ACTION_TYPED_FIELDS]
         fields = [f for f in fields if f not in _ACTION_TYPED_FIELDS]
 
     params = {
@@ -207,6 +210,19 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         for row in data.get("data", []):
             if isinstance(row, dict):
                 _strip_redundant_actions(row)
+
+    # Surface dropped fields so callers know action-typed metrics are missing by
+    # design (incompatible with the requested breakdown), not by bug.
+    if dropped_fields and isinstance(data, dict):
+        breakdown_label = ", ".join(incompatible_breakdowns)
+        data["note"] = (
+            f"Dropped {', '.join(dropped_fields)} from the request because "
+            f"breakdown={breakdown_label} is incompatible with Meta's default "
+            f"action_breakdowns=[action_type]. Action-typed metrics (purchases, "
+            f"leads, cost-per-action) will not appear; spend, impressions, "
+            f"clicks, ctr, cpc, cpm, reach are returned per breakdown value."
+        )
+        data["dropped_fields"] = dropped_fields
 
     return json.dumps(data, indent=2)
 

--- a/meta_ads_mcp/core/insights.py
+++ b/meta_ads_mcp/core/insights.py
@@ -34,6 +34,17 @@ _REDUNDANT_ACTION_PREFIXES = (
 # "(#100) Current combination of data breakdown columns (action_type, X) is invalid".
 _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE = frozenset({
     "platform_position",
+    # media_* creative-asset breakdowns return one row per (entity, asset) but
+    # Meta rejects them when paired with the default action_breakdowns=[action_type].
+    # Drop action-typed fields so the request returns asset-level placement data
+    # without metrics that depend on action_type.
+    "media_asset_url",
+    "media_creator",
+    "media_destination_url",
+    "media_format",
+    "media_origin_url",
+    "media_text_content",
+    "media_type",
 })
 
 _ACTION_TYPED_FIELDS = frozenset({
@@ -92,11 +103,15 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
                    When you pass platform_position, this tool auto-adds publisher_platform and drops the
                    action-typed fields (actions, action_values, conversions, cost_per_action_type) from the
                    response. Use publisher_platform alone if you need action data alongside placement.
-                   Creative Assets: ad_format_asset, body_asset, call_to_action_asset, description_asset, 
+                   Creative Assets: ad_format_asset, body_asset, call_to_action_asset, description_asset,
                                   image_asset, link_url_asset, title_asset, video_asset, media_asset_url,
                                   media_creator, media_destination_url, media_format, media_origin_url,
                                   media_text_content, media_type, creative_relaxation_asset_type,
                                   flexible_format_asset_type, gen_ai_asset_type
+                   NOTE: media_asset_url, media_creator, media_destination_url, media_format,
+                   media_origin_url, media_text_content, and media_type are also incompatible with
+                   the default action_breakdowns=[action_type]. This tool auto-drops the action-typed
+                   fields when any of them is passed so the request returns asset rows successfully.
                    Campaign/Ad Attributes: breakdown_ad_objective, breakdown_reporting_ad_id, app_id, product_id
                    Conversion Tracking: coarse_conversion_value, conversion_destination, standard_event_content_type,
                                        signal_source_bucket, is_conversion_id_modeled, fidelity_type, redownload

--- a/tests/test_insights_breakdown_compat.py
+++ b/tests/test_insights_breakdown_compat.py
@@ -74,3 +74,38 @@ async def test_compatible_breakdown_preserves_action_typed_fields(
     assert "actions" in fields
     assert "action_values" in fields
     assert "cost_per_action_type" in fields
+
+
+@pytest.mark.asyncio
+async def test_incompatible_breakdown_surfaces_dropped_fields_note(
+    mock_api_request, mock_auth_manager
+):
+    """When fields are dropped, the response carries a note + dropped_fields list."""
+    result = await get_insights(
+        account_id="act_test", level="ad", breakdown="media_asset_url"
+    )
+    payload = json.loads(result)
+
+    assert "note" in payload
+    assert "media_asset_url" in payload["note"]
+    assert "Dropped" in payload["note"]
+
+    assert "dropped_fields" in payload
+    assert set(payload["dropped_fields"]) == {
+        "actions",
+        "action_values",
+        "cost_per_action_type",
+        "conversions",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compatible_breakdown_does_not_emit_note(
+    mock_api_request, mock_auth_manager
+):
+    """No drop happened, so no note/dropped_fields keys leak into the response."""
+    result = await get_insights(account_id="act_test", level="ad", breakdown="age")
+    payload = json.loads(result)
+
+    assert "note" not in payload
+    assert "dropped_fields" not in payload

--- a/tests/test_insights_breakdown_compat.py
+++ b/tests/test_insights_breakdown_compat.py
@@ -1,0 +1,76 @@
+"""Tests for breakdowns that conflict with the default action_breakdowns=[action_type].
+
+Meta rejects certain data breakdowns when paired with the default
+action_breakdowns=[action_type]. get_insights auto-drops the action-typed
+fields (actions, action_values, cost_per_action_type, conversions) for those
+breakdowns so the request returns rows successfully.
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch
+
+from meta_ads_mcp.core.insights import get_insights
+
+
+_INCOMPATIBLE_MEDIA_BREAKDOWNS = [
+    "media_asset_url",
+    "media_creator",
+    "media_destination_url",
+    "media_format",
+    "media_origin_url",
+    "media_text_content",
+    "media_type",
+]
+
+
+@pytest.fixture
+def mock_api_request():
+    with patch("meta_ads_mcp.core.insights.make_api_request") as mock:
+        mock.return_value = {"data": [], "paging": {}}
+        yield mock
+
+
+@pytest.fixture
+def mock_auth_manager():
+    with patch("meta_ads_mcp.core.api.auth_manager") as mock, patch(
+        "meta_ads_mcp.core.auth.get_current_access_token"
+    ) as mock_get_token:
+        mock.get_current_access_token.return_value = "test_access_token"
+        mock.is_token_valid.return_value = True
+        mock.app_id = "test_app_id"
+        mock_get_token.return_value = "test_access_token"
+        yield mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("breakdown", _INCOMPATIBLE_MEDIA_BREAKDOWNS)
+async def test_media_breakdown_drops_action_typed_fields(
+    breakdown, mock_api_request, mock_auth_manager
+):
+    """media_* breakdowns must drop action-typed fields to avoid Meta error #100."""
+    await get_insights(account_id="act_test", level="ad", breakdown=breakdown)
+
+    params = mock_api_request.call_args[0][2]
+    fields = params["fields"]
+
+    for action_field in ("actions", "action_values", "cost_per_action_type", "conversions"):
+        assert action_field not in fields, (
+            f"breakdown={breakdown} did not drop {action_field}; got fields={fields}"
+        )
+
+    assert params["breakdowns"] == breakdown
+
+
+@pytest.mark.asyncio
+async def test_compatible_breakdown_preserves_action_typed_fields(
+    mock_api_request, mock_auth_manager
+):
+    """A compatible breakdown like image_asset must keep action-typed fields."""
+    await get_insights(account_id="act_test", level="ad", breakdown="image_asset")
+
+    fields = mock_api_request.call_args[0][2]["fields"]
+    assert "actions" in fields
+    assert "action_values" in fields
+    assert "cost_per_action_type" in fields


### PR DESCRIPTION
## Summary
- get_insights with breakdown set to one of media_asset_url / media_creator / media_destination_url / media_format / media_origin_url / media_text_content / media_type was failing with Meta error #100 (Current combination of data breakdown columns (action_type, X) is invalid). Adds those 7 breakdowns to _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE so the request drops actions, action_values, cost_per_action_type, and conversions and returns asset rows successfully.
- Surfaces the drop in the response so callers know action-typed metrics are absent by design (incompatible with the breakdown), not by bug. Adds a top-level note (human-readable) and dropped_fields (machine-readable) when the drop applies.
- Reported by a customer testing on multiple ad accounts.

## Test plan
- [x] New parametrized test exercises all 7 incompatible breakdowns and asserts action-typed fields are dropped.
- [x] Control test confirms a compatible breakdown (image_asset / age) preserves action-typed fields.
- [x] note + dropped_fields surface only when the drop applies; absent otherwise.
- [x] Full insights test suite passes (33 / 33).
- [x] Reproduced the Meta error on prod for each of the 7 breakdowns before the fix.