### PR TITLE
docs(insights): restore media_type to supported list (1.0.96)

### DIFF
--- a/meta_ads_mcp/core/insights.py
+++ b/meta_ads_mcp/core/insights.py
@@ -93,16 +93,15 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
                    action-typed fields (actions, action_values, conversions, cost_per_action_type) from the
                    response. Use publisher_platform alone if you need action data alongside placement.
                    Creative Assets: ad_format_asset, body_asset, call_to_action_asset, description_asset,
-                                  image_asset, link_url_asset, title_asset, video_asset,
+                                  image_asset, link_url_asset, title_asset, video_asset, media_type,
                                   creative_relaxation_asset_type, flexible_format_asset_type,
                                   gen_ai_asset_type
                    NOTE: Asset breakdowns (image_asset, video_asset, etc.) only return data for ads
                    running with Dynamic Creative; for non-DCO ads, expect empty rows.
                    media_asset_url, media_creator, media_destination_url, media_format,
-                   media_origin_url, media_text_content, and media_type are NOT supported by Meta's
-                   Insights API. Meta returns "(#100) Current combination of data breakdown columns
-                   (action_type, X) is invalid"; the underlying error is "nonexisting field". Use the
-                   asset breakdowns above instead.
+                   media_origin_url, and media_text_content are NOT supported by Meta's Insights API
+                   (Meta returns "(#100) Tried accessing nonexisting field"). Use the asset breakdowns
+                   above instead.
                    Campaign/Ad Attributes: breakdown_ad_objective, breakdown_reporting_ad_id, app_id, product_id
                    Conversion Tracking: coarse_conversion_value, conversion_destination, standard_event_content_type,
                                        signal_source_bucket, is_conversion_id_modeled, fidelity_type, redownload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.95"
+version = "1.0.96"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- PR #105 (v1.0.95) lumped `media_type` in with the 6 truly-nonexistent `media_*` names.
- Direct Meta Graph probe (act_701351919139047 + act_3182643988557192):
  - `media_type` with `action_breakdowns=[]` → 200 OK (real breakdown; returns rows for DCO ads).
  - `media_type` with default action_breakdowns → 400 "(#100) Current combination of data breakdown columns (action_type, media_type) is invalid" — that is the collision Davide saw, not a nonexisting field.
  - `media_asset_url`, `media_creator`, `media_destination_url`, `media_format`, `media_origin_url`, `media_text_content` → 400 "(#100) Tried accessing nonexisting field" (truly invalid).
- Restores `media_type` to the Creative Assets line and rewrites the note to cite only the nonexisting-field error.
- Bumps to 1.0.96.

Companion TS PR: nictuku/pipeboard.co#964 (same correction for the Next.js proxy override).

## Test plan
- [ ] After PyPI publish + deploy, `tools/list` for `get_insights` lists `media_type` and not the other six names.
