### PR TITLE
feat(ads): return effective_status and issues_info on get_ads/get_ad_details

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -463,21 +463,21 @@ async def get_ads(account_id: str, access_token: Optional[str] = None, limit: in
     if adset_id:
         endpoint = f"{adset_id}/ads"
         params = {
-            "fields": "id,name,adset_id,campaign_id,status,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
+            "fields": "id,name,adset_id,campaign_id,status,effective_status,issues_info,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
             "limit": limit
         }
     # Use campaign-specific endpoint if campaign_id is provided
     elif campaign_id:
         endpoint = f"{campaign_id}/ads"
         params = {
-            "fields": "id,name,adset_id,campaign_id,status,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
+            "fields": "id,name,adset_id,campaign_id,status,effective_status,issues_info,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
             "limit": limit
         }
     else:
         # Default to account-level endpoint if no specific filters
         endpoint = f"{account_id}/ads"
         params = {
-            "fields": "id,name,adset_id,campaign_id,status,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
+            "fields": "id,name,adset_id,campaign_id,status,effective_status,issues_info,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs",
             "limit": limit
         }
 
@@ -501,7 +501,7 @@ async def get_ad_details(ad_id: str, access_token: Optional[str] = None) -> str:
         
     endpoint = f"{ad_id}"
     params = {
-        "fields": "id,name,adset_id,campaign_id,status,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs,preview_shareable_link"
+        "fields": "id,name,adset_id,campaign_id,status,effective_status,issues_info,creative,created_time,updated_time,bid_amount,conversion_domain,tracking_specs,preview_shareable_link"
     }
     
     data = await make_api_request(endpoint, access_token, params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.99"
+version = "1.0.100"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Add `effective_status` and `issues_info` to the field list on all three branches of `get_ads()` (account, campaign, adset) and on `get_ad_details()`.
- Bump to 1.0.100.

`status` reflects only the configured ACTIVE/PAUSED state, so callers cannot detect NOT_DELIVERING, DISAPPROVED, WITH_ISSUES, or PENDING_REVIEW from `get_ads`. Adding `effective_status` surfaces the delivery state Meta computes; `issues_info` surfaces the policy/review issue list when there is one.
