### PR TITLE
chore(release): sync server.json version + enforce parity with pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,13 @@ jobs:
       with:
         python-version: "3.10"
         
-    - name: Check version bump
+    - name: Check pyproject.toml and server.json versions match
       run: |
-        # This is a simple check - you might want to make it more sophisticated
-        echo "Current version in pyproject.toml:"
-        grep "version = " pyproject.toml 
+        PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+        JSON_VERSION=$(python -c "import json; print(json.load(open('server.json'))['version'])")
+        echo "pyproject.toml version: $PY_VERSION"
+        echo "server.json version:    $JSON_VERSION"
+        if [ "$PY_VERSION" != "$JSON_VERSION" ]; then
+          echo "::error::pyproject.toml ($PY_VERSION) and server.json ($JSON_VERSION) must match. Bump both."
+          exit 1
+        fi 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         
     - name: Check pyproject.toml and server.json versions match
       run: |
-        PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+        PY_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')
         JSON_VERSION=$(python -c "import json; print(json.load(open('server.json'))['version'])")
         echo "pyproject.toml version: $PY_VERSION"
         echo "server.json version:    $JSON_VERSION"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.93",
+  "version": "1.0.101",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary

- Bump `server.json` version from 1.0.93 → 1.0.101 to match `pyproject.toml`.
- Replace the no-op `validate-version` CI step with a real check that fails when the two versions diverge.

## Why
The "Publish to MCP Registry" job has been failing on every release since the server.json drift (v1.0.99 / v1.0.100 / v1.0.101 all rejected with `cannot publish duplicate version` because the registry already has 1.0.93 from a prior publish). PyPI is unaffected, but the MCP Registry listing stays pinned at 1.0.93.

The CI guard prevents the same drift in future bumps.

## Test plan
- [x] Local check: both files now report 1.0.101.
- [ ] CI `validate-version` job passes on this PR.
- [ ] Next release (v1.0.102 or later) succeeds on the MCP Registry publish step.