### PR TITLE
Translate deprecated instagram_actor_id to instagram_user_id in create_ad_creative

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2145,7 +2145,15 @@ async def create_ad_creative(
                 creative_data["call_to_action"] = cta_osi
 
             if instagram_actor_id:
-                creative_data["instagram_actor_id"] = instagram_actor_id
+                # Meta deprecated instagram_actor_id at POST /act_ID/adcreatives in
+                # Jan 2026 — sending it returns code 100 "Param instagram_actor_id
+                # must be a valid Instagram account id" verbatim. The replacement
+                # is the top-level instagram_user_id field on the AdCreative.
+                # For object_story_spec creatives the migration is handled below
+                # (instagram_user_id is nested inside object_story_spec); the
+                # object_story_id path has no object_story_spec, so the field
+                # lives at the top level.
+                creative_data["instagram_user_id"] = instagram_actor_id
 
         elif use_asset_feed:
             # Build the media array from the provided source
@@ -2511,9 +2519,13 @@ async def create_ad_creative(
         # Make API request to create the creative
         data = await make_api_request(endpoint, access_token, creative_data, method="POST")
 
-        # Check for instagram_actor_id / instagram_user_id permission errors.
-        # This happens when the user's Meta access token lacks the instagram_basic
-        # permission. Re-connecting the Facebook account refreshes the token.
+        # Check for "Param instagram_actor_id must be a valid Instagram account id"
+        # error. This historically meant Meta could not validate the ID. Today (post
+        # Jan 2026) it is *also* what Meta returns when the deprecated
+        # instagram_actor_id field reaches their API, regardless of the ID being
+        # correct. We now translate instagram_actor_id -> instagram_user_id in
+        # every code path, so reaching this branch usually means the ID itself is
+        # not valid for this ad account (e.g. not connected, wrong type).
         if instagram_actor_id and "error" in data:
             err_details = data.get("error", {}).get("details", {})
             inner_msg = ""
@@ -2523,15 +2535,21 @@ async def create_ad_creative(
                     inner_msg = inner_err.get("message", "")
             if "valid Instagram account id" in inner_msg or "instagram_actor_id" in inner_msg.lower():
                 return json.dumps({
-                    "error": "Instagram account not authorized for advertising",
+                    "error": "Instagram account ID not accepted by Meta",
                     "explanation": (
-                        "The Meta API rejected the Instagram account ID. This usually means "
-                        "your Facebook access token is missing the 'instagram_basic' permission, "
-                        "which is required to use Instagram placements in ad creatives."
+                        "Meta rejected the Instagram account ID. The deprecated "
+                        "'instagram_actor_id' field has been translated to "
+                        "'instagram_user_id' in this request, so this most likely "
+                        "means the ID itself is not valid for this ad account — "
+                        "the Instagram account may not be linked to the Facebook "
+                        "page used by the creative, or the ID may belong to a "
+                        "different account."
                     ),
                     "fix": (
-                        "Reconnect your Facebook account at https://pipeboard.co/connections "
-                        "to refresh your access token with the required permissions."
+                        "Run get_instagram_accounts to list the Instagram accounts "
+                        "linked to this ad account and try one of those IDs, or "
+                        "verify in Meta Business Suite that the Instagram account "
+                        "is connected to the Facebook page used by the creative."
                     ),
                     "instagram_actor_id": instagram_actor_id,
                     "meta_error": inner_msg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.101"
+version = "1.0.102"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/test_object_story_id.py
+++ b/tests/test_object_story_id.py
@@ -178,6 +178,114 @@ async def test_create_ad_creative_object_story_id_with_asset_customization():
 
 
 @pytest.mark.asyncio
+async def test_create_ad_creative_object_story_id_translates_instagram_actor_id():
+    """object_story_id + instagram_actor_id must translate to top-level
+    instagram_user_id (Meta deprecated instagram_actor_id at POST
+    /act_ID/adcreatives in Jan 2026; sending the old name returns error 100).
+    """
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api:
+        mock_api.side_effect = [
+            {"id": "creative_osi_ig"},
+            {"id": "creative_osi_ig", "name": "OSI + IG", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            object_story_id="124965744226834_3888007311337206",
+            instagram_actor_id="17841476585143410",
+            call_to_action_type="SHOP_NOW",
+            link_url="https://example.com/",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[0][0][2]
+
+        # Deprecated field name must NOT appear anywhere on the request.
+        assert "instagram_actor_id" not in creative_data
+        # New field name must appear at the top level (object_story_id path has
+        # no object_story_spec to nest it under).
+        assert creative_data["instagram_user_id"] == "17841476585143410"
+        # object_story_id still passed through unchanged.
+        assert creative_data["object_story_id"] == "124965744226834_3888007311337206"
+
+
+@pytest.mark.asyncio
+async def test_create_ad_creative_object_story_id_with_asset_customization_translates_instagram_actor_id():
+    """object_story_id + asset_customization_rules + instagram_actor_id —
+    even when asset_feed_spec is built, the deprecated field must still be
+    translated to instagram_user_id at the top level.
+    """
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api:
+        mock_api.side_effect = [
+            {"id": "creative_osi_ig_acr"},
+            {"id": "creative_osi_ig_acr", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            object_story_id="124965744226834_3888007311337206",
+            asset_customization_rules=[
+                {
+                    "placement_groups": ["STORY"],
+                    "customization_spec": {"video_ids": ["890310874031162"]},
+                }
+            ],
+            instagram_actor_id="17841476585143410",
+            call_to_action_type="SHOP_NOW",
+            link_url="https://example.com/",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[0][0][2]
+        assert "instagram_actor_id" not in creative_data
+        assert creative_data["instagram_user_id"] == "17841476585143410"
+        assert "asset_feed_spec" in creative_data
+
+
+@pytest.mark.asyncio
+async def test_create_ad_creative_object_story_id_invalid_instagram_error_no_longer_blames_scope():
+    """When Meta returns 'Param instagram_actor_id must be a valid Instagram
+    account id' for the object_story_id path, the error enhancement must not
+    falsely claim the token is missing the instagram_basic permission.
+    """
+    with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api:
+        mock_api.return_value = {
+            "error": {
+                "details": {
+                    "error": {
+                        "code": 100,
+                        "message": "Param instagram_actor_id must be a valid Instagram account id",
+                    }
+                }
+            }
+        }
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            object_story_id="124965744226834_3888007311337206",
+            instagram_actor_id="17841476585143410",
+            call_to_action_type="SHOP_NOW",
+            link_url="https://example.com/",
+            access_token="test_token",
+        )
+
+        # The meta_api_tool decorator wraps error responses without a "details"
+        # key as {"data": "<json_string>"} — unwrap both shapes.
+        parsed = json.loads(result)
+        if "data" in parsed and isinstance(parsed["data"], str):
+            parsed = json.loads(parsed["data"])
+        # The misleading instagram_basic explanation must be gone.
+        explanation = parsed.get("explanation", "")
+        assert "instagram_basic" not in explanation
+        # And the fix advice must no longer tell the user to reconnect their
+        # Facebook account — that does not actually resolve this Meta error.
+        fix = parsed.get("fix", "")
+        assert "Reconnect" not in fix
+        # The new guidance should point to get_instagram_accounts.
+        assert "get_instagram_accounts" in fix
+
+
+@pytest.mark.asyncio
 async def test_create_ad_creative_object_story_id_no_media_required():
     """object_story_id bypasses the image_hash/video_id requirement."""
     with patch("meta_ads_mcp.core.ads.make_api_request") as mock_api:


### PR DESCRIPTION
## Summary
- Meta deprecated `instagram_actor_id` at `POST /act_ID/adcreatives` in Jan 2026. Sending the field now returns error 100: `Param instagram_actor_id must be a valid Instagram account id` verbatim — regardless of whether the ID is correct. The replacement is `instagram_user_id`.
- The `object_story_spec` path in `create_ad_creative` already migrated to the nested `instagram_user_id` field, but the `object_story_id` path had no `object_story_spec` to nest under and was still sending the deprecated field at the top level — producing a hard regression on every Instagram-targeted boost.
- This PR translates `instagram_actor_id` -> `instagram_user_id` at the top level of the AdCreative payload in the `object_story_id` branch (matches Meta docs for top-level placement on AdCreative).
- Also rewrites the error enhancement: previously it falsely told users their token was missing the `instagram_basic` permission and pointed them at `/connections`. The new message explains that the deprecated field has been translated already, so reaching the error means the ID itself is not valid for this ad account, and points the user at `get_instagram_accounts`.

## Investigation context
Reported via user feedback. Calls to `create_ad_creative` with `object_story_id` plus a valid Instagram ID were failing with `(#100) Param instagram_actor_id must be a valid Instagram account id`. The deprecated field name is the root cause; the message is misleading because Meta still phrases it as if the ID were wrong.

## Test plan
- [x] Added `test_create_ad_creative_object_story_id_translates_instagram_actor_id` — asserts `creative_data["instagram_user_id"] == "17841476585143410"` and `"instagram_actor_id" not in creative_data`.
- [x] Added `test_create_ad_creative_object_story_id_with_asset_customization_translates_instagram_actor_id` — covers the `asset_customization_rules` variant where `asset_feed_spec` is also built.
- [x] Added `test_create_ad_creative_object_story_id_invalid_instagram_error_no_longer_blames_scope` — asserts the new error enhancement no longer mentions `instagram_basic` or asks the user to reconnect, and routes them to `get_instagram_accounts` instead.
- [x] `tests/test_object_story_id.py` — 14/14 passing.
- [x] Full Python test suite — 432 passing (pre-commit run).
- Companion PR in pipeboard.co covers the analogous TypeScript handlers (bulk, carousel, catalog) that route around the Python tool.