### PR TITLE
feat(insights): accept fields parameter for passthrough

### DIFF
--- a/meta_ads_mcp/core/insights.py
+++ b/meta_ads_mcp/core/insights.py
@@ -52,6 +52,50 @@ _ACTION_TYPED_FIELDS = frozenset({
 })
 
 
+# Default set of fields requested when the caller does not supply `fields`.
+# This is the legacy hard-coded list — kept stable for back-compat.
+_DEFAULT_INSIGHTS_FIELDS = [
+    "account_id", "account_name", "campaign_id", "campaign_name",
+    "adset_id", "adset_name", "ad_id", "ad_name",
+    "impressions", "clicks", "spend", "cpc", "cpm", "ctr", "reach",
+    "frequency", "actions", "action_values", "conversions",
+    "unique_clicks", "cost_per_action_type",
+]
+
+# Identifier/dimension fields that are always merged in when the caller passes
+# a custom `fields` list — without these, downstream tools that group by IDs
+# would break.
+_REQUIRED_DIMENSION_FIELDS = [
+    "account_id", "account_name",
+    "campaign_id", "campaign_name",
+    "adset_id", "adset_name",
+    "ad_id", "ad_name",
+    "date_start", "date_stop",
+]
+
+
+def _build_fields_list(user_fields: Optional[List[str]]) -> List[str]:
+    """Build the list of fields to request from Meta's Insights API.
+
+    When `user_fields` is provided, merges it with the required dimension
+    fields and deduplicates. When None/empty, falls back to the default list
+    so existing callers keep getting the same response shape.
+    """
+    if not user_fields:
+        return list(_DEFAULT_INSIGHTS_FIELDS)
+    seen: set = set()
+    merged: List[str] = []
+    for f in [*_REQUIRED_DIMENSION_FIELDS, *user_fields]:
+        if not isinstance(f, str):
+            continue
+        normalized = f.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        merged.append(normalized)
+    return merged
+
+
 def _strip_redundant_actions(row: dict) -> dict:
     """Remove redundant action-type entries from a single insight row."""
     for key in ("actions", "action_values", "cost_per_action_type"):
@@ -76,6 +120,7 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
                       action_attribution_windows: Optional[List[str]] = None,
                       action_breakdowns: Optional[List[str]] = None,
                       compact: bool = False,
+                      fields: Optional[List[str]] = None,
                       account_id: str = "", campaign_id: str = "",
                       adset_id: str = "", ad_id: str = "") -> str:
     """
@@ -143,12 +188,27 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
                  (omni_*, onsite_web_*, offsite_conversion.fb_pixel_*, etc.) to reduce
                  payload size by ~60%. The canonical action types (purchase, add_to_cart,
                  view_content, etc.) are always preserved. Default: False.
+        fields: Optional list of Meta Insights API field names to request. When None or
+                empty, the legacy default set is returned (impressions, clicks, spend,
+                cpc, cpm, ctr, reach, frequency, actions, action_values, conversions,
+                unique_clicks, cost_per_action_type, plus identifier fields). When
+                provided, the listed fields are passed through to Meta and merged with
+                the required dimension fields (account_id, campaign_id, adset_id, ad_id,
+                date_start, date_stop, *_name). Use this to surface video milestone
+                metrics (video_p25_watched_actions, video_p50_watched_actions,
+                video_p75_watched_actions, video_p95_watched_actions,
+                video_p100_watched_actions, video_thruplay_watched_actions,
+                video_avg_time_watched_actions, video_play_actions,
+                video_30_sec_watched_actions) or ranking diagnostics (quality_ranking,
+                engagement_rate_ranking, conversion_rate_ranking) that aren't in the
+                default set.
 
-    Note on response size: This tool always returns a fixed set of fields (impressions, clicks,
-    spend, cpc, cpm, ctr, reach, actions, action_values, etc.) and cannot filter to a subset.
-    For large result sets (50+ rows), the actions/action_values arrays can make responses very
-    large (1–2MB+). If you only need specific metrics like spend or impressions, consider using
-    bulk_get_insights with compact=true and the fields parameter:
+    Note on response size: By default this tool returns a fixed set of fields (impressions,
+    clicks, spend, cpc, cpm, ctr, reach, actions, action_values, etc.). The `fields`
+    parameter narrows or extends that set. For large result sets (50+ rows), the
+    actions/action_values arrays can make responses very large (1–2MB+). If you only
+    need specific metrics like spend or impressions, consider using bulk_get_insights
+    with compact=true and the fields parameter:
         bulk_get_insights(level="ad", account_ids=[...], compact=true, fields=["spend", "impressions"])
     bulk_get_insights supports level="ad", "adset", "campaign", and "account".
     """
@@ -160,13 +220,10 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         return json.dumps({"error": "No object ID provided. Use object_id, account_id, campaign_id, adset_id, or ad_id."}, indent=2)
         
     endpoint = f"{object_id}/insights"
-    fields = [
-        "account_id", "account_name", "campaign_id", "campaign_name",
-        "adset_id", "adset_name", "ad_id", "ad_name",
-        "impressions", "clicks", "spend", "cpc", "cpm", "ctr", "reach",
-        "frequency", "actions", "action_values", "conversions",
-        "unique_clicks", "cost_per_action_type",
-    ]
+    # Build the field list: caller-supplied `fields` is merged with required
+    # dimension/identifier fields; falling back to the legacy default when no
+    # custom fields are requested keeps existing callers' responses unchanged.
+    request_fields = _build_fields_list(fields)
 
     # Meta rejects platform_position alone or with the default
     # action_breakdowns=[action_type]: it must be paired with publisher_platform,
@@ -178,7 +235,7 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
         breakdown_values = ["publisher_platform", *breakdown_values]
         breakdown_set.add("publisher_platform")
     if breakdown_set & _BREAKDOWNS_INCOMPATIBLE_WITH_ACTION_TYPE:
-        fields = [f for f in fields if f not in _ACTION_TYPED_FIELDS]
+        request_fields = [f for f in request_fields if f not in _ACTION_TYPED_FIELDS]
     # media_type collides with action_breakdowns=[action_type] but is a real
     # field — override action_breakdowns to empty so the request succeeds with
     # the action-typed metrics intact.
@@ -187,7 +244,7 @@ async def get_insights(object_id: str = "", access_token: Optional[str] = None,
     )
 
     params = {
-        "fields": ",".join(fields),
+        "fields": ",".join(request_fields),
         "level": level,
         "limit": limit
     }

--- a/tests/test_insights_fields_passthrough.py
+++ b/tests/test_insights_fields_passthrough.py
@@ -1,0 +1,185 @@
+"""Tests for the `fields` passthrough behavior in get_insights.
+
+Verifies that:
+- Without a `fields` argument, the legacy default set is requested.
+- With a `fields` argument, the listed fields are merged with required
+  dimension identifiers and sent through to Meta verbatim.
+- Video milestone fields and ranking diagnostics survive the merge so the
+  Meta API will return them.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+from meta_ads_mcp.core.insights import get_insights
+
+
+class TestInsightsFieldsPassthrough:
+    @pytest.fixture
+    def mock_auth_manager(self):
+        with patch('meta_ads_mcp.core.api.auth_manager') as mock, \
+             patch('meta_ads_mcp.core.auth.get_current_access_token') as mock_get_token:
+            mock.get_current_access_token.return_value = "test_access_token"
+            mock.is_token_valid.return_value = True
+            mock.app_id = "test_app_id"
+            mock_get_token.return_value = "test_access_token"
+            yield mock
+
+    @pytest.fixture
+    def valid_account_id(self):
+        return "act_701351919139047"
+
+    @pytest.fixture
+    def mock_empty_response(self):
+        return {"data": []}
+
+    @pytest.mark.asyncio
+    async def test_default_fields_are_legacy_list(self, mock_auth_manager, valid_account_id, mock_empty_response):
+        """When `fields` is omitted, the call sends the legacy default field list."""
+        with patch('meta_ads_mcp.core.insights.make_api_request', new_callable=AsyncMock) as mock_api_request:
+            mock_api_request.return_value = mock_empty_response
+
+            await get_insights(object_id=valid_account_id, level="ad", time_range="last_7d")
+
+            call_args = mock_api_request.call_args
+            params = call_args[0][2]
+            fields_csv = params["fields"]
+            fields = fields_csv.split(",")
+
+            # Sanity: identifier fields are present
+            assert "account_id" in fields
+            assert "campaign_id" in fields
+            assert "adset_id" in fields
+            assert "ad_id" in fields
+            # Sanity: legacy metric fields are present
+            assert "impressions" in fields
+            assert "spend" in fields
+            assert "actions" in fields
+
+            # Video milestone fields should NOT be in the default set
+            assert "video_p25_watched_actions" not in fields
+            assert "quality_ranking" not in fields
+
+    @pytest.mark.asyncio
+    async def test_video_milestone_fields_passthrough(self, mock_auth_manager, valid_account_id, mock_empty_response):
+        """Caller-supplied video milestone fields are forwarded to Meta verbatim."""
+        with patch('meta_ads_mcp.core.insights.make_api_request', new_callable=AsyncMock) as mock_api_request:
+            mock_api_request.return_value = mock_empty_response
+
+            await get_insights(
+                object_id=valid_account_id,
+                level="ad",
+                time_range="last_7d",
+                fields=[
+                    "video_p25_watched_actions",
+                    "video_p50_watched_actions",
+                    "video_p75_watched_actions",
+                    "video_p95_watched_actions",
+                    "video_p100_watched_actions",
+                    "video_thruplay_watched_actions",
+                    "video_avg_time_watched_actions",
+                    "video_play_actions",
+                    "video_30_sec_watched_actions",
+                ],
+            )
+
+            call_args = mock_api_request.call_args
+            params = call_args[0][2]
+            fields = params["fields"].split(",")
+
+            for expected in [
+                "video_p25_watched_actions",
+                "video_p50_watched_actions",
+                "video_p75_watched_actions",
+                "video_p95_watched_actions",
+                "video_p100_watched_actions",
+                "video_thruplay_watched_actions",
+                "video_avg_time_watched_actions",
+                "video_play_actions",
+                "video_30_sec_watched_actions",
+            ]:
+                assert expected in fields, f"Expected {expected} in passthrough fields"
+
+            # Required identifier fields are still present
+            assert "ad_id" in fields
+            assert "campaign_id" in fields
+            assert "account_id" in fields
+
+    @pytest.mark.asyncio
+    async def test_ranking_fields_passthrough(self, mock_auth_manager, valid_account_id, mock_empty_response):
+        """Caller-supplied ranking diagnostic fields are forwarded to Meta verbatim."""
+        with patch('meta_ads_mcp.core.insights.make_api_request', new_callable=AsyncMock) as mock_api_request:
+            mock_api_request.return_value = mock_empty_response
+
+            await get_insights(
+                object_id=valid_account_id,
+                level="ad",
+                time_range="last_7d",
+                fields=[
+                    "quality_ranking",
+                    "engagement_rate_ranking",
+                    "conversion_rate_ranking",
+                ],
+            )
+
+            call_args = mock_api_request.call_args
+            params = call_args[0][2]
+            fields = params["fields"].split(",")
+
+            assert "quality_ranking" in fields
+            assert "engagement_rate_ranking" in fields
+            assert "conversion_rate_ranking" in fields
+            # Required dimension fields still merged in
+            assert "ad_id" in fields
+            assert "date_start" in fields
+            assert "date_stop" in fields
+
+    @pytest.mark.asyncio
+    async def test_custom_fields_dedupe_with_dimensions(self, mock_auth_manager, valid_account_id, mock_empty_response):
+        """Overlapping fields (e.g. ad_id) appear once, not twice."""
+        with patch('meta_ads_mcp.core.insights.make_api_request', new_callable=AsyncMock) as mock_api_request:
+            mock_api_request.return_value = mock_empty_response
+
+            await get_insights(
+                object_id=valid_account_id,
+                level="ad",
+                time_range="last_7d",
+                fields=["ad_id", "video_p25_watched_actions", "ad_name"],
+            )
+
+            call_args = mock_api_request.call_args
+            params = call_args[0][2]
+            fields = params["fields"].split(",")
+
+            # Identifier fields appear exactly once
+            assert fields.count("ad_id") == 1
+            assert fields.count("ad_name") == 1
+            assert "video_p25_watched_actions" in fields
+
+    @pytest.mark.asyncio
+    async def test_platform_position_drops_action_typed_fields_with_passthrough(
+        self, mock_auth_manager, valid_account_id, mock_empty_response
+    ):
+        """Existing platform_position guard still drops action-typed fields when custom fields supplied."""
+        with patch('meta_ads_mcp.core.insights.make_api_request', new_callable=AsyncMock) as mock_api_request:
+            mock_api_request.return_value = mock_empty_response
+
+            await get_insights(
+                object_id=valid_account_id,
+                level="ad",
+                time_range="last_7d",
+                breakdown="platform_position",
+                fields=["video_p25_watched_actions"],
+            )
+
+            call_args = mock_api_request.call_args
+            params = call_args[0][2]
+            fields = params["fields"].split(",")
+
+            # video field still passes through
+            assert "video_p25_watched_actions" in fields
+            # action-typed fields are dropped because platform_position conflicts with them
+            assert "actions" not in fields
+            assert "action_values" not in fields
+            assert "conversions" not in fields
+            assert "cost_per_action_type" not in fields


### PR DESCRIPTION
## Summary
- `get_insights` now accepts an optional `fields` list. Names are merged with required dimension identifiers, deduplicated, and sent to the Meta Insights API verbatim.
- Lets callers request video milestone actions (`video_p25/50/75/95/100_watched_actions`, `video_thruplay_watched_actions`, `video_avg_time_watched_actions`, `video_play_actions`, `video_30_sec_watched_actions`) and ranking diagnostics (`quality_ranking`, `engagement_rate_ranking`, `conversion_rate_ranking`).
- The existing platform_position guard against action-typed fields still applies after the merge. Default field list is unchanged when `fields` is omitted.
- Pairs with the Next.js pipeboard.co PR that wires this same change into `bulk_get_insights`.

## Test plan
- [x] `uv run python -m pytest tests/test_insights_fields_passthrough.py -v` → 5/5 pass
- [x] Default-call behavior unchanged (existing fields list still sent when `fields` is omitted)
- [x] Custom-call test asserts every requested field is in the outgoing `fields` query param
- [x] Dedup test confirms overlapping identifiers appear exactly once
- [x] platform_position regression test still drops action-typed fields when custom fields are supplied