### PR TITLE
fix(create_ad_creative): CALL_NOW phone_number must serialize as tel: URI on call_to_action.value.link

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1726,9 +1726,11 @@ async def create_ad_creative(
         asset_customization_rules: List of placement-specific asset overrides for asset_feed_spec.
         phone_number: Phone number for CALL_NOW call-to-action ads (click-to-call).
                      Required when call_to_action_type is CALL_NOW. Use E.164 format
-                     (e.g., "+18005551234"). The number is passed to Meta in
-                     call_to_action.value.phone_number. Common use case: geo-routed
-                     call ads with different phone numbers per ad set.
+                     (e.g., "+18005551234"). The number is sent to Meta as
+                     call_to_action.value.link = "tel:<phone_number>" (Meta v24
+                     rejects a literal "phone_number" key with code 100). Common
+                     use case: geo-routed call ads with different phone numbers
+                     per ad set.
         creative_features_spec: Advantage+ Creative feature opt-ins/opt-outs. Controls individual
                    creative enhancements like image_touchups, text_optimizations, inline_comment,
                    add_text_overlay, music, 3d_animation, etc. Each feature is a dict with
@@ -2122,7 +2124,14 @@ async def create_ad_creative(
                         if lead_gen_form_id:
                             cta_osi_value["lead_gen_form_id"] = lead_gen_form_id
                         if phone_number:
-                            cta_osi_value["phone_number"] = phone_number
+                            # CALL_NOW CTA: Meta v24 rejects a literal "phone_number"
+                            # key inside call_to_action.value with code 100
+                            # ("Invalid keys phone_number were found in param
+                            # call_to_action[value]"). The supported shape is
+                            # call_to_action.value.link = "tel:+<E.164 number>",
+                            # which overrides any website link_url already set
+                            # above (the headline still drives a tap-to-call).
+                            cta_osi_value["link"] = f"tel:{phone_number}"
                         asset_feed_spec_osi["call_to_actions"] = [
                             {"type": call_to_action_type, "value": cta_osi_value}
                         ]
@@ -2139,7 +2148,10 @@ async def create_ad_creative(
                 if lead_gen_form_id:
                     cta_osi_value["lead_gen_form_id"] = lead_gen_form_id
                 if phone_number:
-                    cta_osi_value["phone_number"] = phone_number
+                    # CALL_NOW: see note above — the supported shape is
+                    # call_to_action.value.link = "tel:+<E.164 number>",
+                    # not a "phone_number" key.
+                    cta_osi_value["link"] = f"tel:{phone_number}"
                 if cta_osi_value:
                     cta_osi["value"] = cta_osi_value
                 creative_data["call_to_action"] = cta_osi
@@ -2302,7 +2314,10 @@ async def create_ad_creative(
                     if lead_gen_form_id:
                         cta_value["lead_gen_form_id"] = lead_gen_form_id
                     if phone_number:
-                        cta_value["phone_number"] = phone_number
+                        # CALL_NOW: Meta v24 supports only
+                        # call_to_action.value.link = "tel:+<E.164 number>"; a
+                        # literal "phone_number" key is rejected with code 100.
+                        cta_value["link"] = f"tel:{phone_number}"
                     asset_feed_spec["call_to_actions"] = [
                         {"type": call_to_action_type, "value": cta_value}
                     ]
@@ -2361,7 +2376,9 @@ async def create_ad_creative(
                     if lead_gen_form_id:
                         cta_value["lead_gen_form_id"] = lead_gen_form_id
                     if phone_number:
-                        cta_value["phone_number"] = phone_number
+                        # CALL_NOW: Meta v24 supports only
+                        # call_to_action.value.link = "tel:+<E.164 number>".
+                        cta_value["link"] = f"tel:{phone_number}"
                     if event_id and call_to_action_type in ("EVENT_RSVP", "BUY_TICKETS"):
                         cta_value["event_id"] = event_id
                     if cta_value:
@@ -2403,7 +2420,9 @@ async def create_ad_creative(
                 if lead_gen_form_id:
                     cta_value["lead_gen_form_id"] = lead_gen_form_id
                 if phone_number:
-                    cta_value["phone_number"] = phone_number
+                    # CALL_NOW: Meta v24 supports only
+                    # call_to_action.value.link = "tel:+<E.164 number>".
+                    cta_value["link"] = f"tel:{phone_number}"
                 cta_type = call_to_action_type or ("LEARN_MORE" if link_url else None)
                 if cta_type:
                     cta_data = {"type": cta_type}
@@ -2467,7 +2486,12 @@ async def create_ad_creative(
                     if lead_gen_form_id:
                         cta_value["lead_gen_form_id"] = lead_gen_form_id
                     if phone_number:
-                        cta_value["phone_number"] = phone_number
+                        # CALL_NOW: Meta v24 supports only
+                        # call_to_action.value.link = "tel:+<E.164 number>";
+                        # the literal "phone_number" key is rejected with
+                        # code 100 ("Invalid keys phone_number were found in
+                        # param call_to_action[value]").
+                        cta_value["link"] = f"tel:{phone_number}"
                     if event_id and call_to_action_type in ("EVENT_RSVP", "BUY_TICKETS"):
                         cta_value["event_id"] = event_id
                     if cta_value:

--- a/tests/test_call_now_phone_number.py
+++ b/tests/test_call_now_phone_number.py
@@ -1,4 +1,9 @@
-"""Test that create_ad_creative passes phone_number for CALL_NOW CTAs."""
+"""Test that create_ad_creative serializes phone_number into call_to_action.value.link.
+
+Meta v24 rejects a literal "phone_number" key inside call_to_action.value with
+code 100 ("Invalid keys phone_number were found in param call_to_action[value]").
+The supported shape is call_to_action.value.link = "tel:<E.164 number>".
+"""
 
 import pytest
 import json
@@ -7,8 +12,8 @@ from meta_ads_mcp.core.ads import create_ad_creative
 
 
 @pytest.mark.asyncio
-async def test_simple_image_call_now_includes_phone_number():
-    """Simple image creative with CALL_NOW should include phone_number in CTA value."""
+async def test_simple_image_call_now_serializes_phone_number_as_tel_link():
+    """Simple image creative with CALL_NOW should serialize phone_number into call_to_action.value.link as tel:<number>."""
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
          patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
@@ -47,12 +52,15 @@ async def test_simple_image_call_now_includes_phone_number():
         cta = link_data["call_to_action"]
         assert cta["type"] == "CALL_NOW"
         assert "value" in cta
-        assert cta["value"]["phone_number"] == "+18005551234"
+        # Meta v24: tel: link is the only supported shape.
+        assert cta["value"]["link"] == "tel:+18005551234"
+        # The deprecated literal "phone_number" key must NOT be sent.
+        assert "phone_number" not in cta["value"]
 
 
 @pytest.mark.asyncio
-async def test_simple_image_without_phone_number_has_no_phone_in_cta():
-    """Simple image creative with LEARN_MORE should NOT include phone_number."""
+async def test_simple_image_without_phone_number_has_no_tel_link_in_cta():
+    """Simple image creative with LEARN_MORE should NOT include a tel: link in cta.value."""
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
          patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
@@ -85,15 +93,19 @@ async def test_simple_image_without_phone_number_has_no_phone_in_cta():
         link_data = creative_data["object_story_spec"]["link_data"]
         cta = link_data["call_to_action"]
         assert cta["type"] == "LEARN_MORE"
-        # No phone_number should be in value (value might not exist at all, or
-        # if it does, should not have phone_number)
+        # No phone-related fields should be in value. The deprecated
+        # "phone_number" key must never appear, and the link (if set) must
+        # not be a tel: URI when no phone_number was passed.
         if "value" in cta:
             assert "phone_number" not in cta["value"]
+            link_value = cta["value"].get("link")
+            if link_value is not None:
+                assert not link_value.startswith("tel:")
 
 
 @pytest.mark.asyncio
-async def test_dof_image_call_now_includes_phone_number():
-    """DOF (DEGREES_OF_FREEDOM) image creative with CALL_NOW should include phone_number."""
+async def test_dof_image_call_now_serializes_phone_number_as_tel_link():
+    """DOF (DEGREES_OF_FREEDOM) image creative with CALL_NOW should serialize phone_number as call_to_action.value.link = tel:<number>."""
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
          patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
@@ -132,12 +144,13 @@ async def test_dof_image_call_now_includes_phone_number():
 
         cta = link_data["call_to_action"]
         assert cta["type"] == "CALL_NOW"
-        assert cta["value"]["phone_number"] == "+18005551234"
+        assert cta["value"]["link"] == "tel:+18005551234"
+        assert "phone_number" not in cta["value"]
 
 
 @pytest.mark.asyncio
-async def test_simple_video_call_now_includes_phone_number():
-    """Simple video creative with CALL_NOW should include phone_number in CTA value."""
+async def test_simple_video_call_now_serializes_phone_number_as_tel_link():
+    """Simple video creative with CALL_NOW should serialize phone_number as call_to_action.value.link = tel:<number>."""
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
          patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
@@ -180,4 +193,5 @@ async def test_simple_video_call_now_includes_phone_number():
 
         cta = video_data["call_to_action"]
         assert cta["type"] == "CALL_NOW"
-        assert cta["value"]["phone_number"] == "+18005551234"
+        assert cta["value"]["link"] == "tel:+18005551234"
+        assert "phone_number" not in cta["value"]


### PR DESCRIPTION
## Summary

Meta Marketing API v24 rejects a literal `phone_number` key inside `call_to_action.value` with code 100:

```
(#100) Invalid keys "phone_number" were found in param "call_to_action[value]"
```

The supported shape for CALL_NOW (click-to-call) creatives is:

```json
{
  "type": "CALL_NOW",
  "value": { "link": "tel:+18005551234" }
}
```

Previously `create_ad_creative` set `call_to_action.value.phone_number` instead, so every CALL_NOW ad creative POST failed at the Meta API.

## Changes

- Updated all six CALL_NOW serialization branches in `meta_ads_mcp/core/ads.py`:
  - existing-post (object_story_id) + `asset_customization_rules`
  - existing-post simple
  - DOF / PLACEMENT `asset_feed_spec` image path
  - simple image `link_data`
  - simple video `video_data`
  - second `asset_feed_spec` branch
- Refreshed the `phone_number` docstring to describe the actual serialization (`call_to_action.value.link = "tel:<E.164>"`).
- Updated regression tests in `tests/test_call_now_phone_number.py` to assert the new shape and explicitly forbid the deprecated key.

## Test plan

- [x] `uv run pytest tests/test_call_now_phone_number.py` passes (4 tests)
- [x] Full suite: `uv run pytest` — 448 passed, 9 skipped
- [x] Pre-commit hook green