### PR TITLE
chore(release): bump to 1.0.103

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.102"
+version = "1.0.103"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Releases the CALL_NOW tel: URI fix from #116.

PR #116 fixed Meta v24 rejecting call_to_action.value.phone_number on create_ad_creative — the supported shape is call_to_action.value.link = "tel:<E.164>". The PR landed without a version bump; this bumps pyproject.toml + server.json to 1.0.103 so the fix can ship to PyPI and the production MCP.