### PR TITLE
fix(streamable-http): pin mount to /mcp/ + bump to 1.0.106

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.104"
+__version__ = "1.0.106"
 
 __all__ = [
     'get_ad_accounts',

--- a/meta_ads_mcp/core/server.py
+++ b/meta_ads_mcp/core/server.py
@@ -337,7 +337,11 @@ def main():
         mcp_server.settings.port = args.port
         mcp_server.settings.stateless_http = True
         mcp_server.settings.json_response = not args.sse_response
-        
+        # Mount streamable HTTP at /mcp/ (with trailing slash) so requests
+        # forwarded by an upstream proxy at .../mcp/ are served directly
+        # instead of receiving a 307 redirect to /mcp (the SDK default).
+        mcp_server.settings.streamable_http_path = "/mcp/"
+
         # Import all tool modules to ensure they are registered
         logger.info("Ensuring all tools are registered for HTTP transport")
         from . import accounts, campaigns, adsets, ads, insights, authentication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.104"
+version = "1.0.106"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.104",
+  "version": "1.0.106",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Why

Path B follow-up to PagerDuty incident 129. The 1.0.104 release bundled an
mcp library bump (1.12.2 to 1.23.0) that caused sustained proxy errors
under load behind the internal nginx upstream. 1.0.105 reverted the bump as
a hotfix. This PR re-attempts the bump with the regression-triggering
behavior pinned out.

Empirical finding: the mcp SDK mounts streamable_http at `/mcp` (no
trailing slash) by default. Prod traffic via Next.js forwards to
`http://127.0.0.1:9009/mcp/` (with trailing slash, the URL pattern picked
to avoid an older 307 path), and the SDK responds to `/mcp/` with HTTP 307
to `/mcp`. The redirect plus the SDK 1.23.0 transport semantics is the
plausible root cause of the production failure pattern.

## What

`mcp_server.settings.streamable_http_path = "/mcp/"` pins the canonical
mount with the trailing slash, so prod traffic hits a direct 200 OK
instead of the 307 redirect. With the pin applied, `/mcp/` returns 200
directly and `/mcp` 307s to `/mcp/` (inverse of the SDK default).

Local validation against mcp 1.23.0 confirms the canonical mount is now
the with-slash URL and 400 concurrent requests complete cleanly.

Version bump 1.0.104 to 1.0.106 (1.0.105 is the existing hotfix release on
PyPI with mcp 1.12.2). `mcp[cli]==1.23.0` kept.

## Pairs with

A change in the pipeboard.co deploy repo to add `--host 127.0.0.1` to the
systemd unit (deterministic IPv4 bind, defense in depth) and flip the
deploy.sh health check URL to `/mcp/` so a future SDK regression that
307s the canonical mount is caught at deploy time.

## Canary plan

mcp2 is drained from the load balancer. The deploy workflow matrix runs
mcp2 first with fail-fast=true and the strengthened health check, so a
broken release on mcp2 blocks the mcp1 step. After workflow completion,
synthetic load is driven at mcp2 directly via `curl --resolve` for ~5
minutes while nginx upstream errors are monitored. If clean, mcp2 is
un-drained. If dirty, the rollback target is 1.0.105.

## Test plan

- [x] Local: mcp 1.23.0 with the pin makes `/mcp/` canonical (200); `/mcp`
      307s to `/mcp/`; 400 concurrent requests complete with 400/400 OK.
- [x] Local: full test suite (426 passed, 8 skipped) on the bumped version.
- [ ] mcp2 canary: deploy workflow health check passes; synthetic load
      shows no ECONNREFUSED / 5xx / new TypeError lines for 5 min.
- [ ] Roll mcp1 only after mcp2 canary is green for 5 min.
