### PR TITLE
fix(transport): disable DNS rebinding protection + bump to 1.0.107

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.106"
+__version__ = "1.0.107"
 
 __all__ = [
     'get_ad_accounts',

--- a/meta_ads_mcp/core/server.py
+++ b/meta_ads_mcp/core/server.py
@@ -341,6 +341,15 @@ def main():
         # forwarded by an upstream proxy at .../mcp/ are served directly
         # instead of receiving a 307 redirect to /mcp (the SDK default).
         mcp_server.settings.streamable_http_path = "/mcp/"
+        # Disable DNS rebinding protection. The SDK auto-enables it when the
+        # server binds to a loopback host (127.0.0.1 / localhost / ::1) and
+        # ships a port-wildcard allowlist (127.0.0.1:*). An upstream nginx
+        # with `proxy_set_header Host $host;` strips the port from the Host
+        # header before forwarding, so the allowlist does not match and every
+        # request is rejected with HTTP 421 (the 1.0.106 production
+        # regression). The protection is irrelevant for a loopback-only
+        # service that no external client can reach.
+        mcp_server.settings.transport_security.enable_dns_rebinding_protection = False
 
         # Import all tool modules to ensure they are registered
         logger.info("Ensuring all tools are registered for HTTP transport")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.106"
+version = "1.0.107"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Why

1.0.106 deploy on mcp2 (drained canary host) passed the strengthened
deploy.sh health check (which probes localhost:9000/mcp/, where the Host
header matches the loopback bind), but a follow-up probe through the
internal nginx upstream (127.0.0.1:9009/mcp/) returned HTTP 421 Invalid
Host header for every request.

Root cause: mcp 1.23.0 auto-enables transport_security with a
port-wildcard allowlist (`127.0.0.1:*`, `localhost:*`, `[::1]:*`). The
internal nginx upstream block uses `proxy_set_header Host $host;`,
which strips the port from the original Host header before forwarding.
So the forwarded value (`127.0.0.1`, no port) does not match any
allowlist pattern and every proxied request is rejected.

## What

`transport_security.enable_dns_rebinding_protection = False` explicitly.

DNS rebinding protection is irrelevant for this service: the Python
server binds to 127.0.0.1 only and is not reachable from outside the
host. The only client that can reach it is the internal nginx on the
same loopback interface, so there is no DNS attacker model to protect
against. The protection was useful as a default for general MCP servers
but does not fit this deployment.

Validated locally against mcp 1.23.0: with the disable applied,
Host: 127.0.0.1 (no port) returns 200; without it, 421. Host:
evil.example.com also returns 200 — expected, the protection is off.

## Test plan

- [x] Local: bind to 127.0.0.1, strip-port Host header now returns 200.
- [x] Local: full test suite (426 passed) on the bumped version.
- [ ] mcp2 canary: re-deploy 1.0.107, then probe via internal nginx
      (127.0.0.1:9009/mcp/). Expect HTTP 200, real tools/list result.
- [ ] Sustained synthetic load against mcp2 internal-nginx for 5 min:
      no ECONNREFUSED in `meta-mcp-upstream.log`; no new TypeError.
- [ ] Re-deploy 1.0.107 to mcp1 manually (matrix interception left it
      in a mixed state: conf says 1.0.106 but processes still on 1.0.105).
