### PR TITLE
feat(transport): drop streamable_http_path override + bump to 1.0.108

### DIFF
--- a/meta_ads_mcp/core/server.py
+++ b/meta_ads_mcp/core/server.py
@@ -337,10 +337,6 @@ def main():
         mcp_server.settings.port = args.port
         mcp_server.settings.stateless_http = True
         mcp_server.settings.json_response = not args.sse_response
-        # Mount streamable HTTP at /mcp/ (with trailing slash) so requests
-        # forwarded by an upstream proxy at .../mcp/ are served directly
-        # instead of receiving a 307 redirect to /mcp (the SDK default).
-        mcp_server.settings.streamable_http_path = "/mcp/"
         # Disable DNS rebinding protection. The SDK auto-enables it when the
         # server binds to a loopback host (127.0.0.1 / localhost / ::1) and
         # ships a port-wildcard allowlist (127.0.0.1:*). An upstream nginx
@@ -385,7 +381,7 @@ def main():
         try:
             logger.info("Starting FastMCP server with Streamable HTTP transport")
             print(f"✅ Server configured successfully")
-            print(f"   URL: http://{args.host}:{args.port}{mcp_server.settings.streamable_http_path}/")
+            print(f"   URL: http://{args.host}:{args.port}{mcp_server.settings.streamable_http_path}")
             print(f"   Mode: {'Stateless' if mcp_server.settings.stateless_http else 'Stateful'}")
             print(f"   Format: {'JSON' if mcp_server.settings.json_response else 'SSE'}")
             mcp_server.run(transport="streamable-http")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.107"
+version = "1.0.108"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
- Removes the \`streamable_http_path = \"/mcp/\"\` override in \`meta_ads_mcp/core/server.py\` and bumps to 1.0.108.
- Keeps \`transport_security.enable_dns_rebinding_protection = False\` and the \`mcp[cli]==1.23.0\` pin.

## Why
1.0.106 pinned the SDK mount to \`/mcp/\` based on the assumption that prod forwarded \`/mcp/\`. That assumption was wrong — the internal-nginx (:9009) upstream access log shows every request is \`POST /mcp HTTP/1.1\` (no trailing slash). With the override, the SDK 307-redirected \`/mcp\` -> \`/mcp/\`; the Next.js proxy retry path then detached the undici ArrayBuffer on redirect follow, producing \"Cannot perform ArrayBuffer.prototype.slice on a detached ArrayBuffer\" and the 309 proxy-error/min spike that fired PagerDuty 0198e692-abb3-7ceb-8e68-8c32f232f7e9.

Dropping the override lets the SDK mount at its default \`/mcp\`, which matches prod and serves directly without a 307.

DNS-rebinding protection stays disabled because internal nginx sets \`proxy_set_header Host \$host\` which strips the port -- the SDK's auto-allowlist \`127.0.0.1:*\` never matches, so every request would be 421'd otherwise.

## Test plan
- [ ] mcp2 (drained from LB) manual deploy via SSH: \`bash deploy.sh 1.0.108 9000 9001 9002\`
- [ ] Health gate passes against \`/mcp\` (jakarta PR aligns the URL)
- [ ] Through-stack smoke via \`curl --resolve meta-ads.mcp.pipeboard.co:443:<mcp2-IP>\` with a real Pipeboard token returns 200 + JSON-RPC result
- [ ] Watch \`/var/log/nginx/meta-mcp-upstream.log\` for non-2xx, 5+ min
- [ ] Then mcp1; un-drain mcp2; watch Next.js \`meta_ads_mcp_proxy_error\` 30 min (baseline ~2/min mcp1)

Related: incident 0198e692-abb3-7ceb-8e68-8c32f232f7e9, my-task n_279988ad-2cec-4d83-92fe-a97bb80e9c05.