### PR TITLE
docs(create_ad_creative): promote Placement Asset Customization to a named mode

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -1629,13 +1629,19 @@ async def create_ad_creative(
     """
     Create a new ad creative using an uploaded image hash, video ID, or an existing post.
 
-    Supports five creative modes:
+    Supports six creative modes:
     - **Existing post**: Provide object_story_id (format: {page_id}_{post_id}) to promote an existing
       organic or published post. No image_hash or video_id required. Optionally combine with
       asset_customization_rules to attach a 9:16 video for Story/Reels placements.
     - **Simple image/video**: Single image_hash or video_id with object_story_spec
     - **Multi-variant copy**: Use plural text params (messages[], headlines[], descriptions[]) to test
       multiple text variants with a single image/video. No optimization_type or is_dynamic_creative needed.
+    - **Placement Asset Customization (dual-aspect, non-DC)**: Serve different aspect ratios per placement
+      on a STANDARD ad set without is_dynamic_creative and without the one-ad-per-ad-set cap. Set
+      optimization_type="PLACEMENT" and pass videos=[{video_id, label}, ...] (or images=[{image_hash,
+      label}, ...]) together with asset_customization_rules whose customization_spec references those
+      labels via video_label/image_label. Every label in the rules MUST appear on a videos[]/images[]
+      entry, or Meta returns error_subcode=1487390 ("Adcreative Create Failed").
     - **Dynamic Creative**: Multiple variants with dynamic_creative_spec (requires is_dynamic_creative on ad set)
     - **FLEX/DOF (Advantage+)**: Set optimization_type="DEGREES_OF_FREEDOM" for Meta to auto-optimize
       across all asset combinations without requiring is_dynamic_creative on the ad set


### PR DESCRIPTION
## Summary

Add Placement Asset Customization as a first-class entry in the top-of-docstring modes list for `create_ad_creative`.

PAC (`optimization_type="PLACEMENT"` + labelled `videos[]`/`images[]` + `asset_customization_rules`) is already supported end-to-end in the implementation, but the path was only described inside individual parameter docs. The new entry surfaces:

- the canonical shape for serving different aspect ratios per placement (e.g. 1:1 Feed + 9:16 Reels) on a STANDARD ad set,
- the fact that PAC does NOT require `is_dynamic_creative` on the ad set (and therefore is not subject to the one-ad-per-ad-set cap),
- the label-matching requirement, and the matching `error_subcode=1487390` envelope when labels are missing or mismatched.

No behavior change. Docstring only.

## Test plan
- [x] Pre-commit pytest suite passes locally (no behavior touched).