### PR TITLE
Fix DOF + video + multi-text returning Meta error 2061015

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2324,9 +2324,11 @@ async def create_ad_creative(
                     )
 
             # ------------------------------------------------------------------
-            # Build asset_feed_spec base: DOF vs non-DOF use different patterns.
+            # Build asset_feed_spec base: DOF vs non-DOF use different patterns,
+            # and DOF + video is a third case (link/CTA must be in asset_feed_spec,
+            # not object_story_spec.video_data).
             #
-            # DOF (DEGREES_OF_FREEDOM / FLEX / Advantage+):
+            # DOF (DEGREES_OF_FREEDOM / FLEX / Advantage+) + image:
             #   asset_feed_spec has ONLY: media, optimization_type, text variants.
             #   URL, ad_formats, and CTA go in object_story_spec.link_data.
             #   This matches the working Next.js duplication pattern — Meta's
@@ -2335,25 +2337,35 @@ async def create_ad_creative(
             #   Including those fields causes Meta to silently ignore
             #   asset_feed_spec for multi-image creatives.
             #
+            # DOF + video:
+            #   object_story_spec must be bare {page_id} (Meta v24 rejects
+            #   video_data anchor inside object_story_spec with error 1443048).
+            #   So link_urls, ad_formats, and call_to_action_types MUST live
+            #   in asset_feed_spec — otherwise Meta returns error_subcode
+            #   2061015 ("The link field is required"). Treated like the
+            #   non-DOF path below.
+            #
             # Non-DOF (regular Dynamic Creative):
             #   asset_feed_spec includes link_urls, ad_formats, call_to_action_types
             #   as before (this path is verified working).
             # ------------------------------------------------------------------
             is_dof = optimization_type == "DEGREES_OF_FREEDOM"
-            if is_dof:
-                # DOF: asset_feed_spec has ONLY media, optimization_type, text variants.
-                # URL, ad_formats, and CTA go in object_story_spec.link_data.
+            if is_dof and not is_video:
+                # DOF + image: asset_feed_spec has ONLY media, optimization_type,
+                # text variants. URL, ad_formats, and CTA go in object_story_spec.link_data.
                 asset_feed_spec = {"optimization_type": optimization_type}
                 # Only include ad_formats if explicitly provided by the caller
                 if ad_formats:
                     asset_feed_spec["ad_formats"] = ad_formats
             else:
-                # Non-DOF (including PLACEMENT): link_urls and ad_formats in asset_feed_spec.
+                # Non-DOF (any media) OR DOF + video: link_urls, ad_formats, and
+                # CTA live in asset_feed_spec, object_story_spec stays bare.
                 resolved_ad_formats = ad_formats or (["SINGLE_VIDEO"] if is_video else ["SINGLE_IMAGE"])
-                asset_feed_spec = {
-                    "link_urls": [{"website_url": link_url}],
-                    "ad_formats": resolved_ad_formats,
-                }
+                asset_feed_spec = {"ad_formats": resolved_ad_formats}
+                # Lead-gen flows can omit a website link_url (lead_gen_form_id
+                # provides the destination), so guard link_urls on link_url.
+                if link_url:
+                    asset_feed_spec["link_urls"] = [{"website_url": link_url}]
                 if optimization_type:
                     asset_feed_spec["optimization_type"] = optimization_type
 
@@ -2383,8 +2395,11 @@ async def create_ad_creative(
             elif message:
                 asset_feed_spec["bodies"] = [{"text": message}]
 
-            # CTA in asset_feed_spec only for non-DOF (DOF puts CTA in link_data)
-            if call_to_action_type and not is_dof:
+            # CTA in asset_feed_spec for:
+            #   - any non-DOF path (regular Dynamic Creative)
+            #   - DOF + video (object_story_spec is bare, so CTA must live here)
+            # DOF + image puts CTA in object_story_spec.link_data instead.
+            if call_to_action_type and (not is_dof or is_video):
                 if lead_gen_form_id or phone_number:
                     cta_value: Dict[str, Any] = {}
                     if link_url:
@@ -2420,10 +2435,12 @@ async def create_ad_creative(
             # asset_feed_spec.
             # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
             # ------------------------------------------------------------------
-            if video_id or not is_dof:
-                # video_id branch: asset_feed_spec.videos already carries the
-                # video + thumbnail; link_urls + call_to_action_types carry
-                # the destination + CTA. object_story_spec must be bare.
+            if is_video or not is_dof:
+                # Video branch (single video_id OR videos[]): asset_feed_spec.videos
+                # already carries the video + thumbnail; link_urls +
+                # call_to_action_types carry the destination + CTA. Including a
+                # video_data anchor here triggers Meta API v24 error 1443048
+                # ("object_story_spec ill formed"), so object_story_spec stays bare.
                 # Non-DOF image (PLACEMENT etc.) branch: same shape — URLs,
                 # images, CTA live exclusively in asset_feed_spec.
                 creative_data["object_story_spec"] = {

--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -2426,26 +2426,42 @@ async def create_ad_creative(
             # ------------------------------------------------------------------
             # Build object_story_spec for asset_feed_spec creatives.
             #
-            # When asset_feed_spec.videos[] carries the video, object_story_spec
-            # MUST contain only page_id (plus instagram_user_id, appended later).
-            # Adding a video_data anchor here triggers Meta API v24 error 1443048
-            # ("object_story_spec ill formed"). Per Meta's official docs, the
-            # canonical shape for asset_feed_spec.videos[] is bare page_id —
-            # the video, thumbnail, link URL, and CTA all live in
-            # asset_feed_spec.
+            # Three sub-cases:
+            #
+            # - Non-DOF (regular Dynamic Creative, PLACEMENT, etc.) — bare
+            #   {page_id}. Everything (link, CTA, media) lives in
+            #   asset_feed_spec. Verified working on v24.
+            #
+            # - DOF + video — object_story_spec MUST carry a `link_data.link`
+            #   anchor. Meta v24 rejects bare {page_id} for DOF + video with
+            #   error_subcode 2061015 ("The link field is required";
+            #   blame_field_specs=[["link"]]). A video_data anchor would trip
+            #   1443048 ("object_story_spec ill formed") instead, so we use a
+            #   minimal link_data: {link: <url>}. The video/thumbnail/text
+            #   variants stay in asset_feed_spec — this is verified via the
+            #   sandbox account (creative ids 3081153525608342, 1026522600054410
+            #   created 2026-05-27).
+            #
+            # - DOF + image — handled in the `else` branch below: full
+            #   link_data anchor with image_hash, link, CTA, etc.
+            #
             # Ref: https://developers.facebook.com/docs/marketing-api/dynamic-creative/dynamic-creative-optimization
             # ------------------------------------------------------------------
             if is_video or not is_dof:
-                # Video branch (single video_id OR videos[]): asset_feed_spec.videos
-                # already carries the video + thumbnail; link_urls +
-                # call_to_action_types carry the destination + CTA. Including a
-                # video_data anchor here triggers Meta API v24 error 1443048
-                # ("object_story_spec ill formed"), so object_story_spec stays bare.
-                # Non-DOF image (PLACEMENT etc.) branch: same shape — URLs,
-                # images, CTA live exclusively in asset_feed_spec.
                 creative_data["object_story_spec"] = {
                     "page_id": page_id,
                 }
+                if is_dof and is_video:
+                    # Anchor link for Meta v24 DOF + video. Use link_url when
+                    # provided; fall back to the Meta lead-gen placeholder so
+                    # lead_gen_form_id flows still produce a non-empty anchor.
+                    anchor_link = link_url or (
+                        "http://fb.me/" if lead_gen_form_id else None
+                    )
+                    if anchor_link:
+                        creative_data["object_story_spec"]["link_data"] = {
+                            "link": anchor_link,
+                        }
             else:
                 # DOF image: link_data serves as the "anchor" creative template.
                 link_data = {}

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -332,27 +332,34 @@ async def test_video_creative_with_dof_optimization():
 
         # PR-C: video metadata moved from object_story_spec.video_data to asset_feed_spec.
         # Thumbnail (was video_data.image_url) is now on asset_feed_spec.videos[].
+        # DOF + video also requires a link_data.link anchor on object_story_spec
+        # to satisfy Meta v24 (otherwise error_subcode 2061015).
         oss = creative_data["object_story_spec"]
         assert "video_data" not in oss
-        assert "link_data" not in oss
-        assert oss == {"page_id": "123456789"}
+        assert oss == {
+            "page_id": "123456789",
+            "link_data": {"link": "https://example.com/"},
+        }
         assert afs["videos"][0]["thumbnail_url"] == "https://example.com/auto-thumb.jpg"
 
 
 @pytest.mark.asyncio
 async def test_video_creative_with_dof_includes_link_and_cta_in_asset_feed_spec():
     """Regression for DOF + video + multi-text: link_urls + call_to_action_types
-    must land in asset_feed_spec.
+    must land in asset_feed_spec AND object_story_spec must carry a
+    link_data.link anchor.
 
-    For DOF + video, object_story_spec must be bare {page_id} (Meta v24 rejects a
-    video_data anchor inside object_story_spec with error 1443048). That means
-    link_urls and the CTA must live in asset_feed_spec — otherwise Meta returns
-    error_subcode 2061015 ("The link field is required") and the CTA is dropped.
+    For DOF + video, Meta v24 requires both:
+      - asset_feed_spec carries link_urls + call_to_action_types (a
+        video_data anchor inside object_story_spec trips error 1443048).
+      - object_story_spec carries `link_data: {link: <url>}` (a bare
+        `{page_id}` trips error_subcode 2061015 "link field required").
+    A video_data anchor would trip 1443226 ("thumbnail required") instead.
+    Verified empirically against the v24 sandbox 2026-05-27.
 
-    Before the fix, the DOF branch in create_ad_creative produced an
-    asset_feed_spec containing only optimization_type/ad_formats/media/text and
-    omitted link_urls + call_to_action_types entirely, making DOF + video +
-    multi-text creatives unreachable through the MCP tool.
+    Before the fix, the DOF branch produced bare object_story_spec and
+    omitted link_urls + call_to_action_types from asset_feed_spec, making
+    DOF + video + multi-text creatives unreachable through the MCP tool.
     """
 
     with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
@@ -406,11 +413,14 @@ async def test_video_creative_with_dof_includes_link_and_cta_in_asset_feed_spec(
         assert afs["titles"] == [{"text": "Headline A"}, {"text": "Headline B"}]
         assert afs["descriptions"] == [{"text": "Desc A"}, {"text": "Desc B"}]
 
-        # object_story_spec must be bare {page_id} — a video_data or link_data
-        # anchor here breaks Meta v24 (error 1443048 "object_story_spec ill
-        # formed").
+        # object_story_spec must carry the link_data.link anchor (Meta v24
+        # rejects a bare {page_id} with error_subcode 2061015 "link field
+        # required"). A video_data anchor would trip 1443226 instead.
         oss = creative_data["object_story_spec"]
-        assert oss == {"page_id": "123456789"}
+        assert oss == {
+            "page_id": "123456789",
+            "link_data": {"link": "https://example.com/landing"},
+        }
 
 
 @pytest.mark.asyncio
@@ -457,8 +467,11 @@ async def test_video_creative_with_dof_and_call_now_cta_uses_call_to_actions_plu
         ]
         assert "call_to_action_types" not in afs
 
-        # object_story_spec stays bare for DOF + video.
-        assert creative_data["object_story_spec"] == {"page_id": "123456789"}
+        # DOF + video object_story_spec needs the link_data.link anchor.
+        assert creative_data["object_story_spec"] == {
+            "page_id": "123456789",
+            "link_data": {"link": "https://example.com/"},
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -340,6 +340,128 @@ async def test_video_creative_with_dof_optimization():
 
 
 @pytest.mark.asyncio
+async def test_video_creative_with_dof_includes_link_and_cta_in_asset_feed_spec():
+    """Regression for DOF + video + multi-text: link_urls + call_to_action_types
+    must land in asset_feed_spec.
+
+    For DOF + video, object_story_spec must be bare {page_id} (Meta v24 rejects a
+    video_data anchor inside object_story_spec with error 1443048). That means
+    link_urls and the CTA must live in asset_feed_spec — otherwise Meta returns
+    error_subcode 2061015 ("The link field is required") and the CTA is dropped.
+
+    Before the fix, the DOF branch in create_ad_creative produced an
+    asset_feed_spec containing only optimization_type/ad_formats/media/text and
+    omitted link_urls + call_to_action_types entirely, making DOF + video +
+    multi-text creatives unreachable through the MCP tool.
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page"
+        }
+
+        mock_api.side_effect = [
+            # 1) Auto-fetch video thumbnail
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            # 2) POST create creative
+            {"id": "creative_vid_dof_cta"},
+            # 3) GET creative details
+            {"id": "creative_vid_dof_cta", "name": "DOF Video", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_dof_cta",
+            name="DOF Video Creative",
+            link_url="https://example.com/landing",
+            optimization_type="DEGREES_OF_FREEDOM",
+            messages=["Body A", "Body B"],
+            headlines=["Headline A", "Headline B"],
+            descriptions=["Desc A", "Desc B"],
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+        afs = creative_data["asset_feed_spec"]
+
+        # DOF + video: AFS must carry the link and CTA — these were the missing
+        # fields that caused error_subcode 2061015.
+        assert afs["link_urls"] == [{"website_url": "https://example.com/landing"}]
+        assert afs["call_to_action_types"] == ["LEARN_MORE"]
+
+        # AFS also keeps the DOF optimization signal and the video itself.
+        assert afs["optimization_type"] == "DEGREES_OF_FREEDOM"
+        assert afs["ad_formats"] == ["SINGLE_VIDEO"]
+        assert afs["videos"] == [
+            {"video_id": "vid_dof_cta", "thumbnail_url": "https://example.com/auto-thumb.jpg"}
+        ]
+
+        # Multi-text variants flow through unchanged.
+        assert afs["bodies"] == [{"text": "Body A"}, {"text": "Body B"}]
+        assert afs["titles"] == [{"text": "Headline A"}, {"text": "Headline B"}]
+        assert afs["descriptions"] == [{"text": "Desc A"}, {"text": "Desc B"}]
+
+        # object_story_spec must be bare {page_id} — a video_data or link_data
+        # anchor here breaks Meta v24 (error 1443048 "object_story_spec ill
+        # formed").
+        oss = creative_data["object_story_spec"]
+        assert oss == {"page_id": "123456789"}
+
+
+@pytest.mark.asyncio
+async def test_video_creative_with_dof_and_call_now_cta_uses_call_to_actions_plural():
+    """DOF + video + CALL_NOW: phone_number must travel as
+    call_to_actions: [{type, value: {link: 'tel:...'}}] in asset_feed_spec
+    (the singular call_to_action_types drops the phone payload).
+    """
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            {"picture": "https://example.com/auto-thumb.jpg"},
+            {"id": "creative_vid_dof_call_now"},
+            {"id": "creative_vid_dof_call_now", "name": "DOF Video CALL_NOW", "status": "ACTIVE"},
+        ]
+
+        await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_dof_phone",
+            name="DOF Video CALL_NOW",
+            link_url="https://example.com/",
+            optimization_type="DEGREES_OF_FREEDOM",
+            messages=["Body"],
+            call_to_action_type="CALL_NOW",
+            phone_number="+15551234567",
+            access_token="test_token",
+        )
+
+        creative_data = mock_api.call_args_list[1][0][2]
+        afs = creative_data["asset_feed_spec"]
+
+        # CALL_NOW with phone_number must land in the plural call_to_actions
+        # binding with tel: link inside value — not call_to_action_types.
+        assert afs["call_to_actions"] == [
+            {"type": "CALL_NOW", "value": {"link": "tel:+15551234567"}}
+        ]
+        assert "call_to_action_types" not in afs
+
+        # object_story_spec stays bare for DOF + video.
+        assert creative_data["object_story_spec"] == {"page_id": "123456789"}
+
+
+@pytest.mark.asyncio
 async def test_video_and_image_hash_mutual_exclusivity():
     """Test that providing both video_id and image_hash returns an error."""
 


### PR DESCRIPTION
## Summary

`create_ad_creative` with `optimization_type='DEGREES_OF_FREEDOM'` + `video_id` + multi-text (`messages[]` / `headlines[]` / `descriptions[]`) was unreachable through the MCP tool: Meta returned error_subcode **2061015** ("The link field is required", `blame_field_specs=[["link"]]`).

E2E testing against the v24 sandbox showed Meta needs **both** pieces in place on DOF + video creatives:

1. `asset_feed_spec` carries `link_urls` + `ad_formats` + `call_to_action_types`.
2. `object_story_spec` carries a minimal `link_data: {link: <url>}` anchor.

The original handlers were missing both. The first commit on this PR added (1). The second commit adds (2) after E2E testing surfaced that (1) alone was not enough — a video_data anchor would trip 1443226 ("thumbnail required") instead, so the link_data variant is the only working shape.

## Change

`meta_ads_mcp/core/ads.py` (`create_ad_creative`):
- DOF AFS branch gated to image-only (`is_dof and not is_video`). DOF + video builds AFS like the non-DOF path (link_urls + ad_formats + call_to_action_types).
- CTA gate widened from `not is_dof` to `not is_dof or is_video`.
- For `is_dof and is_video`, `object_story_spec` gets `link_data: {link: anchor_link}` where `anchor_link` is `link_url` if provided, else `http://fb.me/` (Meta's lead-gen placeholder) if `lead_gen_form_id` is present.

## E2E verification

Verified via `pipeboard mcp tools-call --tool bulk_create_ad_creatives` against the v24 sandbox on 2026-05-27. The corrected shape returns success and a creative_id (no more 2061015). Sample working creative ids: 862281692948780, 1026522600054410, 3081153525608342.

## Test plan

- [x] `tests/test_video_creatives.py` — DOF + video assertions updated to expect the link_data anchor on object_story_spec
- [x] Full pytest suite: 464 passed, 9 skipped
- [x] E2E via pipeboard CLI: `bulk_create_ad_creatives` returns `success: true` + creative_id

Paired with pipeboard.co PR #1317 (TypeScript mirror).
