### PR TITLE
Bump version to 1.0.111

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.110"
+__version__ = "1.0.111"
 
 __all__ = [
     'get_ad_accounts',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.110"
+version = "1.0.111"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Cuts a release for the create_ad_creative DOF + video + multi-text fix (PR #130).

## Changes since 1.0.110
- #128 — docs(readme) writes-first framing
- #129 — docs(readme) Pipeboard MCP family
- #130 — Fix create_ad_creative DOF + video + multi-text returning Meta error 2061015

## Release plan
1. Merge this version bump
2. gh release create 1.0.111 --repo pipeboard-co/meta-ads-mcp
3. gh workflow run deploy-meta-ads-mcp.yml -f version=1.0.111 (pipeboard.co)

No dependency bumps in this window; safe to release.