### PR TITLE
fix(video): surface real thumbnail frame and processing status

### DIFF
--- a/meta_ads_mcp/core/ads.py
+++ b/meta_ads_mcp/core/ads.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import logging
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Dict, Any, List, Tuple, Union
 import io
 from PIL import Image as PILImage
 from mcp.server.fastmcp import Image
@@ -954,7 +954,15 @@ async def _fetch_image_by_hash(
 async def get_ad_video(ad_id: str = "", video_id: str = "", account_id: str = "", access_token: Optional[str] = None) -> str:
     """
     Get video details and source URL for a Meta ad video creative. Returns the video source URL
-    (direct download link), thumbnail URL, and metadata (title, description, duration).
+    (direct download link), thumbnail URL, processing status, and metadata (title, description,
+    duration).
+
+    Also useful for polling after bulk_upload_ad_videos: ``video_status`` is
+    ``"processing"`` while Meta is still transcoding and ``"ready"`` when the
+    real video frames (and a usable thumbnail) are available. Calling
+    create_ad_creative before status is "ready" returns an error because the
+    only thumbnail Meta returns during processing is a generic placeholder
+    that would be permanently stored on the creative.
 
     Provide either ad_id (to auto-extract the video from the ad creative) or video_id directly.
     Providing account_id is strongly recommended — it enables the advideos edge which works
@@ -999,7 +1007,7 @@ async def get_ad_video(ad_id: str = "", video_id: str = "", account_id: str = ""
                 "hint": "This ad may be an image ad. Use get_ad_image instead."
             }, indent=2)
 
-    video_fields = "source,title,description,length,picture,thumbnails,created_time"
+    video_fields = "source,title,description,length,picture,thumbnails,status,created_time"
 
     # Strategy 1: Try fetching via the ad account's advideos edge.
     # Direct GET /{video_id} fails for BM-shared tokens (error 100/33) and
@@ -1038,10 +1046,34 @@ async def get_ad_video(ad_id: str = "", video_id: str = "", account_id: str = ""
     if "error" in video_data:
         return json.dumps({"error": f"Could not get video {video_id}", "details": video_data}, indent=2)
 
+    # Mirror the selection logic used by create_ad_creative's auto-fetch: the
+    # `thumbnails.data[0].uri` entry is the real frame Meta extracted, while
+    # `picture` can be the generic processing-state placeholder. Prefer the
+    # frame-derived URL when available so callers passing this thumbnail_url
+    # back into update_ad_creative / create_ad_creative get a real preview.
+    thumbs = (
+        video_data.get("thumbnails", {}).get("data", [])
+        if isinstance(video_data.get("thumbnails"), dict)
+        else []
+    )
+    thumbnail_url: Optional[str] = None
+    if thumbs and isinstance(thumbs[0], dict) and thumbs[0].get("uri"):
+        thumbnail_url = thumbs[0]["uri"]
+    else:
+        thumbnail_url = video_data.get("picture")
+
+    status_obj = video_data.get("status")
+    video_status: Optional[str] = None
+    if isinstance(status_obj, dict):
+        vs = status_obj.get("video_status")
+        if isinstance(vs, str):
+            video_status = vs
+
     result = {
         "video_id": video_id,
         "source_url": video_data.get("source"),
-        "thumbnail_url": video_data.get("picture"),
+        "thumbnail_url": thumbnail_url,
+        "video_status": video_status,
         "title": video_data.get("title"),
         "description": video_data.get("description"),
         "duration_seconds": video_data.get("length"),
@@ -1053,6 +1085,14 @@ async def get_ad_video(ad_id: str = "", video_id: str = "", account_id: str = ""
 
     if not result["source_url"]:
         result["warning"] = "No source URL returned. The video may have been deleted or you may lack permissions."
+
+    if video_status == "processing":
+        # Make the processing state easy to spot — callers using this tool to
+        # poll readiness before create_ad_creative want a fast signal.
+        result["warning_processing"] = (
+            "Video is still being processed by Meta. The thumbnail_url above "
+            "may be a generic placeholder until processing completes."
+        )
 
     return json.dumps(result, indent=2)
 
@@ -1607,23 +1647,64 @@ def _normalize_text_variants(items: Optional[List[Any]]) -> Optional[List[Dict[s
     return out
 
 
-async def _fetch_video_thumbnail(vid_id: str, access_token: str) -> Optional[str]:
-    """Fetch a thumbnail URL for a Meta video. Returns None on any failure.
+async def _fetch_video_thumbnail_with_status(
+    vid_id: str, access_token: str
+) -> Tuple[Optional[str], Optional[str]]:
+    """Fetch a thumbnail URL for a Meta video and the video's processing status.
 
-    Prefers the pre-generated `thumbnails.data[0].uri` over `picture` because
-    `picture` can sometimes be a small placeholder while the thumbnails entry
-    is the actual generated frame Meta uses for video previews.
+    Returns ``(thumbnail_url, video_status)``:
+      - ``thumbnail_url`` is the best frame-derived URL we can find. Prefers
+        ``thumbnails.data[0].uri`` over ``picture`` because ``picture`` can be
+        Meta's generic processing-state placeholder while ``thumbnails`` is
+        empty (transcoding still in progress). When the video is still
+        processing AND no ``thumbnails`` entries exist, we return ``None`` for
+        the URL so the caller can either retry or surface a clear error
+        instead of persisting the placeholder onto the creative.
+      - ``video_status`` is Meta's ``status.video_status`` (``"processing"``,
+        ``"ready"``, ``"expired"``, ``"error"``) or ``None`` if Meta did not
+        return it.
+
+    Any exception is swallowed and reported as ``(None, None)`` — callers
+    treat that as "no thumbnail available", same as before.
     """
     try:
-        info = await make_api_request(vid_id, access_token, {"fields": "picture,thumbnails"})
-        if isinstance(info, dict):
-            thumbs = info.get("thumbnails", {}).get("data", [])
-            if thumbs and thumbs[0].get("uri"):
-                return thumbs[0]["uri"]
-            return info.get("picture") or None
+        info = await make_api_request(
+            vid_id, access_token, {"fields": "picture,thumbnails,status"}
+        )
+        if not isinstance(info, dict):
+            return (None, None)
+        status_obj = info.get("status")
+        video_status: Optional[str] = None
+        if isinstance(status_obj, dict):
+            vs = status_obj.get("video_status")
+            if isinstance(vs, str):
+                video_status = vs
+        thumbs = info.get("thumbnails", {}).get("data", []) if isinstance(info.get("thumbnails"), dict) else []
+        if thumbs and isinstance(thumbs[0], dict) and thumbs[0].get("uri"):
+            return (thumbs[0]["uri"], video_status)
+        # No thumbnails entry. `picture` is only trustworthy when the video
+        # is actually ready — otherwise Meta returns its own placeholder URL
+        # for the processing state, which would silently ship as the creative
+        # thumbnail and never get refreshed.
+        picture = info.get("picture")
+        if picture and (video_status is None or video_status == "ready"):
+            return (picture, video_status)
+        return (None, video_status)
     except Exception as e:
         logger.warning(f"Failed to auto-fetch thumbnail for video {vid_id}: {e}")
-    return None
+        return (None, None)
+
+
+async def _fetch_video_thumbnail(vid_id: str, access_token: str) -> Optional[str]:
+    """Backwards-compatible wrapper around :func:`_fetch_video_thumbnail_with_status`.
+
+    Kept for callers that only need the URL and treat ``None`` as "no
+    thumbnail available". New code should prefer the ``_with_status`` variant
+    so it can distinguish "video still processing" from "no thumbnail at all"
+    and surface a clear error to the user.
+    """
+    url, _status = await _fetch_video_thumbnail_with_status(vid_id, access_token)
+    return url
 
 
 @mcp_server.tool()
@@ -1727,7 +1808,18 @@ async def create_ad_creative(
                   that include instagram_actor_id are routed through asset_feed_spec so that
                   ad_formats=["SINGLE_VIDEO"] is always included in the API request.
         thumbnail_url: Thumbnail image URL for video creatives. Recommended when using video_id.
-                      Meta will auto-generate a thumbnail if not provided.
+                      Meta will auto-generate a thumbnail if not provided — Pipeboard
+                      will fetch the best available frame from the uploaded video.
+                      IMPORTANT: when the video was just uploaded via
+                      bulk_upload_ad_videos, Meta needs a few seconds to transcode
+                      it. If create_ad_creative is called before transcoding
+                      completes, the only thumbnail Meta returns is a generic
+                      processing-state placeholder, which would be permanently
+                      stored on the creative. In that case create_ad_creative
+                      returns an error with video_status: "processing" — wait
+                      a few seconds (poll with get_ad_video until video_status
+                      is "ready") and retry, or pass thumbnail_url explicitly
+                      (any public image URL works).
         optimization_type: Optional. Valid values:
                           - "DEGREES_OF_FREEDOM": FLEX (Advantage+) creatives where Meta auto-optimizes
                             across all asset combinations. At least one multi-variant asset field required.
@@ -2168,10 +2260,31 @@ async def create_ad_creative(
         # ("Could not auto-fetch thumbnail for video None"). Per-video thumbnail
         # fetching for the videos[] loop is handled separately downstream.
         if video_id and not thumbnail_url:
-            fetched = await _fetch_video_thumbnail(video_id, access_token)
+            fetched, video_status = await _fetch_video_thumbnail_with_status(
+                video_id, access_token
+            )
             if fetched:
                 thumbnail_url = fetched
                 logger.info(f"Auto-fetched video thumbnail: {thumbnail_url[:80]}...")
+            elif video_status == "processing":
+                # Meta is still transcoding the video. `picture` at this point is
+                # a generic processing placeholder, not a real video frame — if
+                # we ship it the creative is permanently stuck with that
+                # placeholder even after Meta finishes processing. Fail fast with
+                # an actionable error so the caller can retry (typically takes a
+                # few seconds for short videos) or pass thumbnail_url explicitly.
+                return json.dumps({
+                    "error": (
+                        f"Video {video_id} is still being processed by Meta — no "
+                        "frame-derived thumbnail is available yet. The creative "
+                        "would otherwise be stored with a generic placeholder."
+                    ),
+                    "video_status": video_status,
+                    "suggestions": [
+                        "Wait a few seconds for Meta to finish processing (use get_ad_video to check status), then retry create_ad_creative.",
+                        "Or pass thumbnail_url explicitly (any public image URL is accepted).",
+                    ],
+                }, indent=2)
             else:
                 logger.warning(f"Could not auto-fetch thumbnail for video {video_id}")
 
@@ -2258,10 +2371,15 @@ async def create_ad_creative(
                 # field of object_story_spec"). Parallel fetch via asyncio.gather to
                 # avoid N sequential round trips for N videos.
                 thumb_coros = [
-                    _fetch_video_thumbnail(str(v["video_id"]), access_token)
+                    _fetch_video_thumbnail_with_status(str(v["video_id"]), access_token)
                     for v in videos if not v.get("thumbnail_url")
                 ]
                 fetched_iter = iter(await asyncio.gather(*thumb_coros) if thumb_coros else [])
+                # Collect videos that are still transcoding so we can return one
+                # actionable error covering all of them — beats Meta's generic
+                # 1443226 ("specify image_hash or image_url") response and
+                # avoids persisting the placeholder picture on the creative.
+                still_processing: List[str] = []
                 videos_array = []
                 for v in videos:
                     vid_id = str(v["video_id"])
@@ -2269,13 +2387,17 @@ async def create_ad_creative(
                     if v.get("thumbnail_url"):
                         entry["thumbnail_url"] = v["thumbnail_url"]
                     else:
-                        fetched_thumb = next(fetched_iter, None)
+                        fetched_thumb, fetched_status = next(fetched_iter, (None, None))
                         if fetched_thumb:
                             entry["thumbnail_url"] = fetched_thumb
                             logger.info(
                                 f"Auto-fetched thumbnail for video {vid_id}: "
                                 f"{str(fetched_thumb)[:80]}..."
                             )
+                        elif fetched_status == "processing":
+                            still_processing.append(vid_id)
+                            # Skip emitting this entry — we'll bail out below.
+                            continue
                         else:
                             # Proceed without a thumbnail; Meta will return its own
                             # actionable error (1443226) if it actually requires one.
@@ -2288,6 +2410,21 @@ async def create_ad_creative(
                     elif v.get("adlabels"):
                         entry["adlabels"] = v["adlabels"]
                     videos_array.append(entry)
+
+                if still_processing:
+                    return json.dumps({
+                        "error": (
+                            "One or more videos are still being processed by "
+                            "Meta — no frame-derived thumbnails are available "
+                            "yet. The creative would otherwise be stored with "
+                            "generic processing placeholders."
+                        ),
+                        "video_ids_still_processing": still_processing,
+                        "suggestions": [
+                            "Wait a few seconds for Meta to finish processing (use get_ad_video to check status), then retry create_ad_creative.",
+                            "Or pass thumbnail_url explicitly inside each videos[] entry (any public image URL is accepted).",
+                        ],
+                    }, indent=2)
             elif video_id:
                 # Single video in asset_feed_spec uses "videos" key
                 videos_array = [{"video_id": video_id}]

--- a/tests/test_get_ad_video.py
+++ b/tests/test_get_ad_video.py
@@ -118,7 +118,7 @@ class TestGetAdVideo:
             # Without ad_id, only the direct node call is made
             mock_api.assert_called_once_with(
                 "5555", "test_token",
-                {"fields": "source,title,description,length,picture,thumbnails,created_time"}
+                {"fields": "source,title,description,length,picture,thumbnails,status,created_time"}
             )
 
     async def test_get_ad_video_no_video_in_creative(self):
@@ -192,6 +192,57 @@ class TestGetAdVideo:
             mock_api.assert_called_once()
             call_args = mock_api.call_args
             assert "act_999888/advideos" in call_args[0][0]
+
+    async def test_get_ad_video_prefers_thumbnails_uri_over_picture(self):
+        """When the video object exposes both `picture` and a non-empty `thumbnails`
+        list, the response must surface the pre-generated frame URI (the real
+        frame) instead of the small `picture` placeholder.
+        """
+        mock_video_details = {
+            "source": "https://video-xx.fbcdn.net/v/preferred.mp4",
+            "picture": "https://example.com/small-placeholder.jpg",
+            "thumbnails": {
+                "data": [
+                    {"uri": "https://example.com/real-frame.jpg"},
+                    {"uri": "https://example.com/other.jpg"},
+                ]
+            },
+            "status": {"video_status": "ready"},
+            "length": 12.0,
+        }
+
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_video_details
+
+            result = await get_ad_video(access_token="test_token", video_id="vid_pref")
+            data = json.loads(result)
+
+            assert data["thumbnail_url"] == "https://example.com/real-frame.jpg"
+            assert data["video_status"] == "ready"
+            assert "warning_processing" not in data
+
+    async def test_get_ad_video_reports_processing_status(self):
+        """When the video is still transcoding, the response must surface the
+        processing status and a warning so callers know not to use the
+        thumbnail_url yet (it would be Meta's placeholder).
+        """
+        mock_video_details = {
+            "source": None,
+            "picture": "https://example.com/processing-placeholder.jpg",
+            "thumbnails": {"data": []},
+            "status": {"video_status": "processing"},
+            "length": None,
+        }
+
+        with patch('meta_ads_mcp.core.ads.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_video_details
+
+            result = await get_ad_video(access_token="test_token", video_id="vid_proc")
+            data = json.loads(result)
+
+            assert data["video_status"] == "processing"
+            assert "warning_processing" in data
+            assert "still being processed" in data["warning_processing"]
 
     async def test_get_ad_video_account_id_lookup_fails(self):
         """When account_id lookup fails, skip advideos edge and go direct."""

--- a/tests/test_video_creatives.py
+++ b/tests/test_video_creatives.py
@@ -1370,10 +1370,10 @@ async def test_videos_array_auto_fetches_missing_thumbnails():
         # First positional arg is the video_id (endpoint path).
         ids_fetched = {thumb_call_a.args[0], thumb_call_b.args[0]}
         assert ids_fetched == {"a", "b"}
-        # Both thumbnail GETs should request picture,thumbnails.
+        # Both thumbnail GETs should request picture,thumbnails,status.
         for c in (thumb_call_a, thumb_call_b):
             params = c.args[2]
-            assert params.get("fields") == "picture,thumbnails"
+            assert params.get("fields") == "picture,thumbnails,status"
 
         # POST is the 3rd call. asset_feed_spec.videos must carry the fetched URIs.
         creative_data = mock_api.call_args_list[2][0][2]
@@ -1448,14 +1448,196 @@ async def test_video_thumbnail_fetch_prefers_thumbnails_uri_over_picture():
                     {"uri": "https://example.com/another-thumb.jpg"},
                 ]
             },
+            "status": {"video_status": "ready"},
         }
 
         result = await _fetch_video_thumbnail("vid_123", "test_token")
 
         assert result == "https://example.com/preferred-thumb.jpg"
-        # Sanity: it should have asked for both fields.
+        # Sanity: it should have asked for the relevant fields.
         params = mock_api.call_args.args[2]
-        assert params.get("fields") == "picture,thumbnails"
+        assert params.get("fields") == "picture,thumbnails,status"
+
+
+@pytest.mark.asyncio
+async def test_video_thumbnail_fetch_with_status_returns_processing_signal():
+    """When a video is still processing AND only `picture` is set (the generic
+    processing placeholder), the with-status helper must NOT return the
+    placeholder URL — it must signal "processing" so the caller can fail fast
+    instead of permanently storing the placeholder on the creative.
+    """
+    from meta_ads_mcp.core.ads import _fetch_video_thumbnail_with_status
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api:
+        mock_api.return_value = {
+            "picture": "https://example.com/processing-placeholder.jpg",
+            "thumbnails": {"data": []},
+            "status": {"video_status": "processing"},
+        }
+
+        url, status = await _fetch_video_thumbnail_with_status("vid_p1", "tok")
+
+        assert url is None, "Placeholder must not be returned during processing"
+        assert status == "processing"
+
+
+@pytest.mark.asyncio
+async def test_video_thumbnail_fetch_with_status_picture_ok_when_ready():
+    """When the video is `ready` but `thumbnails` is empty, falling back to
+    `picture` is fine — that's a real frame at that point.
+    """
+    from meta_ads_mcp.core.ads import _fetch_video_thumbnail_with_status
+
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api:
+        mock_api.return_value = {
+            "picture": "https://example.com/real-frame.jpg",
+            "thumbnails": {"data": []},
+            "status": {"video_status": "ready"},
+        }
+
+        url, status = await _fetch_video_thumbnail_with_status("vid_r1", "tok")
+
+        assert url == "https://example.com/real-frame.jpg"
+        assert status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_create_ad_creative_errors_when_video_still_processing():
+    """create_ad_creative with a freshly uploaded video_id (still transcoding)
+    and no explicit thumbnail_url must return a clear "still processing" error
+    instead of silently storing Meta's processing placeholder on the creative.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        # Single call: the auto-fetch returns the processing-state shape.
+        # No POST/GET should follow because we bail out with an error.
+        mock_api.side_effect = [
+            {
+                "picture": "https://example.com/processing-placeholder.jpg",
+                "thumbnails": {"data": []},
+                "status": {"video_status": "processing"},
+            },
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_processing",
+            name="Processing Video Ad",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        # Only the auto-fetch happened — no creative POST.
+        assert mock_api.call_count == 1
+        parsed = parse_error_result(result)
+        assert "error" in parsed
+        assert "still being processed" in parsed["error"]
+        assert parsed.get("video_status") == "processing"
+
+
+@pytest.mark.asyncio
+async def test_create_ad_creative_videos_array_errors_on_processing():
+    """videos=[] path must also bail with an actionable error when any video
+    is still being transcoded.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        mock_api.side_effect = [
+            # First video is still processing (parallel fetch — order matches
+            # the videos[] iteration).
+            {
+                "picture": "https://example.com/proc-placeholder.jpg",
+                "thumbnails": {"data": []},
+                "status": {"video_status": "processing"},
+            },
+            # Second video is ready with a real thumbnail.
+            {
+                "picture": "https://example.com/real-pic.jpg",
+                "thumbnails": {"data": [{"uri": "https://example.com/real-frame.jpg"}]},
+                "status": {"video_status": "ready"},
+            },
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            videos=[
+                {"video_id": "vid_processing", "label": "feed"},
+                {"video_id": "vid_ready", "label": "story"},
+            ],
+            name="Mixed Processing Status",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        # No creative POST should be made because at least one video isn't ready.
+        assert mock_api.call_count == 2
+        parsed = parse_error_result(result)
+        assert "error" in parsed
+        assert "still being processed" in parsed["error"]
+        ids = parsed.get("video_ids_still_processing") or []
+        assert "vid_processing" in ids
+        assert "vid_ready" not in ids
+
+
+@pytest.mark.asyncio
+async def test_create_ad_creative_explicit_thumbnail_skips_status_check():
+    """If the caller passes thumbnail_url explicitly, we must NOT auto-fetch
+    and must NOT block on video processing status — the caller is asserting
+    a known-good thumbnail.
+    """
+    with patch('meta_ads_mcp.core.ads.make_api_request') as mock_api, \
+         patch('meta_ads_mcp.core.ads._discover_pages_for_account') as mock_discover:
+
+        mock_discover.return_value = {
+            "success": True,
+            "page_id": "123456789",
+            "page_name": "Test Page",
+        }
+
+        # No auto-fetch should fire. Only POST + GET.
+        mock_api.side_effect = [
+            {"id": "creative_explicit_thumb"},
+            {"id": "creative_explicit_thumb", "name": "Explicit Thumb", "status": "ACTIVE"},
+        ]
+
+        result = await create_ad_creative(
+            account_id="act_123456",
+            video_id="vid_processing",
+            thumbnail_url="https://example.com/caller-thumb.jpg",
+            name="Caller Thumb",
+            link_url="https://example.com/",
+            message="hi",
+            headline="hi",
+            call_to_action_type="LEARN_MORE",
+            access_token="test_token",
+        )
+
+        # No auto-fetch round trip.
+        assert mock_api.call_count == 2
+        creative_data = mock_api.call_args_list[0][0][2]
+        # Thumbnail used in object_story_spec.video_data.
+        oss = creative_data.get("object_story_spec", {})
+        assert oss.get("video_data", {}).get("image_url") == "https://example.com/caller-thumb.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When a video has not finished transcoding, Meta returns a tiny placeholder image as the video's `picture` field (size 228x119, marked `stp=dst-jpg_p228x119`) instead of a real frame from the video. Using that placeholder as the thumbnail in `object_story_spec` or `asset_feed_spec` yields a video ad with a small/blank poster in Ads Manager.

This change makes the MCP video tooling poll-aware:

- `get_ad_video` / `_fetch_video_thumbnail_with_status`: request `thumbnails,status` alongside `picture` when fetching video metadata. Prefer `thumbnails.data[0].uri` (a real frame URL) over `picture`. Surface `video_status` (`processing` | `ready` | `error` | `expired`) and a `warning_processing` hint so callers know to poll instead of using a placeholder.
- `create_ad_creative`: block attempts to wrap a still-processing video without an explicit `thumbnail_url`, with a clear error pointing callers at `get_ad_video` for polling.

## Test plan

- [x] `uv run python -m pytest` — 471 tests passing locally
- [x] E2E via `pipeboard mcp` against real Meta API on a known video — confirmed `thumbnail_url` is now a real frame URL distinct from the placeholder `picture`
- [ ] CI green
- [ ] Reviewer confirms tool description text reads clearly to a calling LLM