### PR TITLE
feat(adsets): add CBO spend-limit fields to get_adsets / get_adset_details

### DIFF
--- a/meta_ads_mcp/core/adsets.py
+++ b/meta_ads_mcp/core/adsets.py
@@ -25,21 +25,35 @@ async def get_adsets(account_id: str, access_token: Optional[str] = None, limit:
 
     account_id = ensure_act_prefix(account_id)
 
+    # daily_min_spend_target / daily_spend_cap / lifetime_min_spend_target /
+    # lifetime_spend_cap are the CBO ad set spend limits. They are included
+    # here so callers can verify (via a readback) whether a create_adset /
+    # update_adset call that set them actually persisted the value on Meta's
+    # side — there was previously no way to check via this tool at all.
+    adset_fields = (
+        "id,name,campaign_id,status,daily_budget,lifetime_budget,"
+        "daily_min_spend_target,daily_spend_cap,lifetime_min_spend_target,lifetime_spend_cap,"
+        "targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,"
+        "billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,"
+        "frequency_control_specs{event,interval_days,max_frequency},"
+        "regional_regulated_categories,regional_regulation_identities"
+    )
+
     # Change endpoint based on whether campaign_id is provided
     if campaign_id:
         endpoint = f"{campaign_id}/adsets"
         params = {
-            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
+            "fields": adset_fields,
             "limit": limit
         }
     else:
         # Use account endpoint if no campaign_id is given
         endpoint = f"{account_id}/adsets"
         params = {
-            "fields": "id,name,campaign_id,status,daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,is_dynamic_creative,frequency_control_specs{event,interval_days,max_frequency},regional_regulated_categories,regional_regulation_identities",
+            "fields": adset_fields,
             "limit": limit
         }
-        # Note: Removed the attempt to add campaign_id to params for the account endpoint case, 
+        # Note: Removed the attempt to add campaign_id to params for the account endpoint case,
         # as it was ineffective and the logic now uses the correct endpoint for campaign filtering.
 
     data = await make_api_request(endpoint, access_token, params)
@@ -67,9 +81,21 @@ async def get_adset_details(adset_id: str, access_token: Optional[str] = None) -
         return json.dumps({"error": "No ad set ID provided"}, indent=2)
     
     endpoint = f"{adset_id}"
-    # Explicitly prioritize frequency_control_specs in the fields request
+    # Explicitly prioritize frequency_control_specs in the fields request.
+    # daily_min_spend_target / daily_spend_cap / lifetime_min_spend_target /
+    # lifetime_spend_cap (CBO ad set spend limits) are included so callers can
+    # verify whether a create_adset / update_adset call that set them actually
+    # persisted the value — previously there was no way to check via this tool.
     params = {
-        "fields": "id,name,campaign_id,status,frequency_control_specs{event,interval_days,max_frequency},daily_budget,lifetime_budget,targeting,bid_amount,bid_adjustments,bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,created_time,updated_time,attribution_spec,destination_type,promoted_object,pacing_type,budget_remaining,dsa_beneficiary,dsa_payor,is_dynamic_creative,regional_regulated_categories,regional_regulation_identities"
+        "fields": (
+            "id,name,campaign_id,status,frequency_control_specs{event,interval_days,max_frequency},"
+            "daily_budget,lifetime_budget,daily_min_spend_target,daily_spend_cap,"
+            "lifetime_min_spend_target,lifetime_spend_cap,targeting,bid_amount,bid_adjustments,"
+            "bid_strategy,bid_constraints,optimization_goal,billing_event,start_time,end_time,"
+            "created_time,updated_time,attribution_spec,destination_type,promoted_object,"
+            "pacing_type,budget_remaining,dsa_beneficiary,dsa_payor,is_dynamic_creative,"
+            "regional_regulated_categories,regional_regulation_identities"
+        )
     }
     
     data = await make_api_request(endpoint, access_token, params)

--- a/tests/test_adset_spend_targets.py
+++ b/tests/test_adset_spend_targets.py
@@ -1,0 +1,79 @@
+"""
+Tests that get_adsets / get_adset_details request the CBO ad set spend-limit
+fields (daily_min_spend_target, daily_spend_cap, lifetime_min_spend_target,
+lifetime_spend_cap) so a caller can verify whether create_adset / update_adset
+actually persisted them.
+
+Note: create_adset / update_adset themselves do NOT accept these fields as
+kwargs here — they are forwarded on the Next.js (pipeboard.co) side instead,
+which forks create_adset onto a direct Meta Graph API call. This file only
+covers the read-side field lists, which remain served by this Python backend.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from meta_ads_mcp.core.adsets import get_adsets, get_adset_details
+
+SPEND_TARGET_FIELDS = [
+    "daily_min_spend_target",
+    "daily_spend_cap",
+    "lifetime_min_spend_target",
+    "lifetime_spend_cap",
+]
+
+
+@pytest.mark.asyncio
+async def test_get_adset_details_fields_include_spend_targets():
+    sample_response = {
+        "id": "120",
+        "name": "CBO Adset",
+        "daily_min_spend_target": "7000",
+    }
+    with patch('meta_ads_mcp.core.adsets.make_api_request', new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = sample_response
+
+        result = await get_adset_details(adset_id="120", access_token="test_token")
+        data = json.loads(result)
+        assert data["daily_min_spend_target"] == "7000"
+
+        call_args = mock_api.call_args
+        params = call_args[0][2]
+        fields = params.get("fields", "")
+        for field in SPEND_TARGET_FIELDS:
+            assert field in fields
+
+
+@pytest.mark.asyncio
+async def test_get_adsets_fields_include_spend_targets_account_endpoint():
+    sample_response = {"data": []}
+    with patch('meta_ads_mcp.core.adsets.make_api_request', new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = sample_response
+
+        await get_adsets(account_id="act_123", access_token="test_token", limit=1)
+
+        call_args = mock_api.call_args
+        params = call_args[0][2]
+        fields = params.get("fields", "")
+        for field in SPEND_TARGET_FIELDS:
+            assert field in fields
+
+
+@pytest.mark.asyncio
+async def test_get_adsets_fields_include_spend_targets_campaign_endpoint():
+    sample_response = {"data": []}
+    with patch('meta_ads_mcp.core.adsets.make_api_request', new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = sample_response
+
+        await get_adsets(
+            account_id="act_123", access_token="test_token", limit=1, campaign_id="cmp_1"
+        )
+
+        call_args = mock_api.call_args
+        endpoint = call_args[0][0]
+        params = call_args[0][2]
+        fields = params.get("fields", "")
+        assert endpoint == "cmp_1/adsets"
+        for field in SPEND_TARGET_FIELDS:
+            assert field in fields


### PR DESCRIPTION
## Summary

`daily_min_spend_target` / `daily_spend_cap` / `lifetime_min_spend_target` / `lifetime_spend_cap` (the CBO ad set minimum/maximum spend limit fields) were missing from both `get_adsets` and `get_adset_details`'s Meta field lists — so there was no way to verify via the API whether a `create_adset` / `update_adset` call that set one of these fields actually persisted the value on Meta's side.

This is the read-side half of a customer-reported bug (Enterprise plan, CBO campaign creative testing) where `create_adset` silently dropped `daily_min_spend_target` with no error, and the customer had no way to confirm the drop via `get_adset_details` either.

**No change needed to `create_adset` / `update_adset` in this repo** — both are now fully forked to the Next.js MCP server (pipeboard-co/pipeboard.co), so the write-side fix (forwarding these fields, and routing to Graph API v25.0 where they actually persist) lives there: pipeboard-co/pipeboard.co#1888.

## Changes

- `get_adsets`: added the four fields to both the campaign-filtered and account-level `fields` params.
- `get_adset_details`: added the four fields to its `fields` param.

## Test plan

- [x] New tests in `tests/test_adset_spend_targets.py` (get_adset_details + both get_adsets endpoint branches request the new fields)
- [x] Full suite: `uv run python -m pytest -q` → 532 passed, 9 skipped, 2 deselected (pre-existing)
- [x] Live E2E verified against Sandbox `act_1276764704512927` (see pipeboard-co/pipeboard.co#1888 for the full trace): after creating an ad set with these fields via the corrected `create_adset`, `get_adset_details` run against a local copy of this patched code correctly echoed back the persisted values.

⚠️ Per the repo's release process, this needs a version bump + `gh release create` + `deploy-meta-ads-mcp.yml` to reach production — none of that is done here; opening the PR only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)