### PR TITLE
fix(security): stop make_api_request mutating the caller's params dict (access token leak)

### DIFF
--- a/meta_ads_mcp/core/api.py
+++ b/meta_ads_mcp/core/api.py
@@ -198,7 +198,12 @@ async def make_api_request(
         "User-Agent": USER_AGENT,
     }
     
-    request_params = params or {}
+    # Shallow-copy the caller's params: this function injects credentials
+    # (access_token, appsecret_proof) and JSON-stringifies dict/list values
+    # below. Mutating the caller's dict leaked the access token into tool
+    # responses that echo their params back (e.g. update_ad_creative's
+    # attempted_updates on error 1815573).
+    request_params = dict(params) if params else {}
     request_params["access_token"] = access_token
 
     # Add appsecret_proof when META_APP_SECRET is configured.

--- a/tests/test_make_api_request_param_mutation.py
+++ b/tests/test_make_api_request_param_mutation.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Regression tests: make_api_request must NOT mutate the caller's params dict.
+
+make_api_request injects credentials (access_token, appsecret_proof) and
+JSON-stringifies dict/list values into the outgoing request. Before the fix it
+did this on the caller's own dict (request_params = params or {} shares the
+reference for non-empty dicts), so any tool that echoes its params back to the
+user AFTER the call leaked the access token — real case: update_ad_creative
+returns `attempted_updates` in its error_subcode-1815573 response, which came
+back carrying `access_token` plus json.dumps-stringified specs.
+"""
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from meta_ads_mcp.core.api import make_api_request
+
+
+def _mock_response():
+    """A minimal successful httpx response."""
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.json.return_value = {"success": True}
+    response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.fixture
+def mock_httpx_client():
+    """Patch httpx.AsyncClient so no network I/O happens."""
+    with patch("meta_ads_mcp.core.api.httpx.AsyncClient") as mock_client_cls:
+        client = MagicMock()
+        client.get = AsyncMock(return_value=_mock_response())
+        client.post = AsyncMock(return_value=_mock_response())
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_post_does_not_mutate_caller_params(mock_httpx_client):
+    """POST path: credentials and json.dumps'd values must stay out of the caller's dict."""
+    caller_params = {
+        "name": "My creative",
+        "object_story_spec": {"link_data": {"message": "New text"}},
+        "headlines": [{"text": "H1"}],
+    }
+    snapshot = {
+        "name": "My creative",
+        "object_story_spec": {"link_data": {"message": "New text"}},
+        "headlines": [{"text": "H1"}],
+    }
+
+    await make_api_request("123/endpoint", "SECRET_TOKEN", caller_params, method="POST")
+
+    assert caller_params == snapshot, (
+        "make_api_request mutated the caller's params dict — tools that echo "
+        "their params back (e.g. update_ad_creative attempted_updates) would "
+        "leak the access token and stringified specs"
+    )
+    assert "access_token" not in caller_params
+    assert "appsecret_proof" not in caller_params
+    assert isinstance(caller_params["object_story_spec"], dict)
+
+
+@pytest.mark.asyncio
+async def test_post_still_sends_credentials_and_stringified_values(mock_httpx_client):
+    """The outgoing request keeps the old wire format (token + JSON strings)."""
+    caller_params = {"object_story_spec": {"link_data": {"message": "x"}}}
+
+    await make_api_request("123/endpoint", "SECRET_TOKEN", caller_params, method="POST")
+
+    sent = mock_httpx_client.post.call_args.kwargs["data"]
+    assert sent["access_token"] == "SECRET_TOKEN"
+    assert isinstance(sent["object_story_spec"], str)
+
+
+@pytest.mark.asyncio
+async def test_get_does_not_mutate_caller_params(mock_httpx_client):
+    """GET path: same guarantee for query-style calls."""
+    caller_params = {"fields": "id,name", "targeting_spec": {"geo_locations": {"countries": ["US"]}}}
+    snapshot = {"fields": "id,name", "targeting_spec": {"geo_locations": {"countries": ["US"]}}}
+
+    await make_api_request("123/endpoint", "SECRET_TOKEN", caller_params, method="GET")
+
+    assert caller_params == snapshot
+    assert "access_token" not in caller_params


### PR DESCRIPTION
## Security fix: user access token leaked into tool responses

`make_api_request` takes the caller's params dict **by reference** (`request_params = params or {}`) and then mutates it in place: it injects `access_token` / `appsecret_proof` and `json.dumps`-stringifies every dict/list value. Any tool that echoes its params back to the user AFTER calling `make_api_request` therefore leaks the user's Meta access token in the tool response.

Real, reproduced case: `update_ad_creative` returns `attempted_updates` in its error_subcode-1815573 response. Recorded from a live run against this server:

```
"attempted_updates": {
  "object_story_spec": "{\"link_data\": {\"message\": \"New primary text\"}}",
  "access_token": "EAALFMGdfPjkBRieeT0Bk3541RTJEkTqLe..."   <-- real user token
}
```

(Found while recording parity fixtures for the Next.js fork — pipeboard.co#1911 documents the same finding on the consumer side.)

Other latent echo sites guarded by the same fix: `update_campaign` and `create_budget_schedule` include `params_sent` in their exception paths.

## Fix

Shallow-copy the params before injecting credentials and serializing:

```python
request_params = dict(params) if params else {}
```

The outgoing wire format is unchanged — the token is still sent and dict/list values are still JSON-stringified in the request itself; only the caller's dict stays untouched.

## Tests

New `tests/test_make_api_request_param_mutation.py` (httpx mocked, no network):

```
tests/test_make_api_request_param_mutation.py::test_post_does_not_mutate_caller_params PASSED
tests/test_make_api_request_param_mutation.py::test_post_still_sends_credentials_and_stringified_values PASSED
tests/test_make_api_request_param_mutation.py::test_get_does_not_mutate_caller_params PASSED
3 passed
```

Adjacent suites exercising the real `make_api_request` (`tests/test_account_disabled_error.py`, `tests/test_http_auth_security.py`):

```
28 passed, 1 warning in 7.37s
```
