### PR TITLE
fix(targeting): estimate_audience_size preflight rejects custom_locations

### DIFF
--- a/meta_ads_mcp/core/targeting.py
+++ b/meta_ads_mcp/core/targeting.py
@@ -164,7 +164,10 @@ async def estimate_audience_size(
                 "cities",
                 "zips",
                 "geo_markets",
-                "country_groups"
+                "country_groups",
+                "custom_locations",
+                "places",
+                "electoral_districts",
             ]:
                 val = geo.get(key)
                 if isinstance(val, list) and len(val) > 0:
@@ -187,7 +190,7 @@ async def estimate_audience_size(
         return json.dumps({
             "error": "Missing target audience location",
             "details": "Select at least one location in targeting.geo_locations or include a custom audience.",
-            "action_required": "Add geo_locations with countries/regions/cities/zips or include custom_audiences.",
+            "action_required": "Add geo_locations with countries/regions/cities/zips/geo_markets/custom_locations/places/electoral_districts, or include custom_audiences.",
             "example": {
                 "geo_locations": {"countries": ["US"]},
                 "age_min": 25,
@@ -224,7 +227,7 @@ async def estimate_audience_size(
                         "error": "Missing target audience location",
                         "details": raw_err.get("error_user_msg") or "Select at least one location, or choose a custom audience.",
                         "endpoint_used": f"{account_id}/reachestimate",
-                        "action_required": "Add geo_locations with at least one of countries/regions/cities/zips or include custom_audiences.",
+                        "action_required": "Add geo_locations with at least one of countries/regions/cities/zips/geo_markets/custom_locations/places/electoral_districts or include custom_audiences.",
                         "blame_field_specs": raw_err.get("error_data", {}).get("blame_field_specs") if isinstance(raw_err.get("error_data"), dict) else None
                     }, indent=2)
             except Exception:

--- a/tests/test_estimate_audience_size.py
+++ b/tests/test_estimate_audience_size.py
@@ -276,6 +276,153 @@ class TestEstimateAudienceSize:
         assert "example" in nested_data
     
     @pytest.mark.asyncio
+    async def test_missing_location_rejected_by_preflight(self):
+        """Targeting with no location keys and no custom audience should be rejected before
+        ever reaching the reachestimate endpoint."""
+        targeting_spec = {
+            "age_min": 22,
+            "age_max": 55
+        }
+
+        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
+            result = await estimate_audience_size(
+                access_token="test_token",
+                account_id="act_123456789",
+                targeting=targeting_spec
+            )
+
+            # Preflight check should short-circuit before calling the Graph API
+            mock_api.assert_not_called()
+
+            result_data = json.loads(result)
+            assert "data" in result_data
+            nested_data = json.loads(result_data["data"])
+            assert nested_data["error"] == "Missing target audience location"
+            assert "action_required" in nested_data
+
+    @pytest.mark.asyncio
+    async def test_custom_locations_only_passes_preflight(self):
+        """Regression test: a targeting spec whose only location signal is
+        geo_locations.custom_locations (radius targeting) must pass Pipeboard's preflight
+        check and reach the reachestimate endpoint. Previously this was incorrectly
+        rejected with "Missing target audience location" (custom_locations was missing
+        from the recognized geo_locations keys)."""
+        mock_response = {
+            "data": [
+                {
+                    "estimate_mau": 42000,
+                    "estimate_dau": [],
+                    "bid_estimates": {},
+                    "unsupported_targeting": []
+                }
+            ]
+        }
+
+        targeting_spec = {
+            "age_min": 22,
+            "age_max": 55,
+            "geo_locations": {
+                "custom_locations": [
+                    {"latitude": 40.759, "longitude": -73.9895, "radius": 1.5, "distance_unit": "mile"}
+                ],
+                "location_types": ["home"]
+            },
+            "targeting_automation": {"advantage_audience": 0}
+        }
+
+        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await estimate_audience_size(
+                access_token="test_token",
+                account_id="act_123456789",
+                targeting=targeting_spec
+            )
+
+            mock_api.assert_called_once_with(
+                "act_123456789/reachestimate",
+                "test_token",
+                {"targeting_spec": targeting_spec},
+                method="GET"
+            )
+
+            result_data = json.loads(result)
+            assert result_data["success"] is True
+            assert result_data["estimated_audience_size"] == 42000
+
+    @pytest.mark.asyncio
+    async def test_places_only_passes_preflight(self):
+        """A targeting spec using only geo_locations.places (e.g. targeting around a named
+        place/landmark) should also pass the preflight location check."""
+        mock_response = {
+            "data": [
+                {
+                    "estimate_mau": 15000,
+                    "estimate_dau": [],
+                    "bid_estimates": {},
+                    "unsupported_targeting": []
+                }
+            ]
+        }
+
+        targeting_spec = {
+            "age_min": 18,
+            "age_max": 65,
+            "geo_locations": {
+                "places": [{"key": 129672430416115, "name": "SFO", "radius": 10, "distance_unit": "mile"}]
+            }
+        }
+
+        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await estimate_audience_size(
+                access_token="test_token",
+                account_id="act_123456789",
+                targeting=targeting_spec
+            )
+
+            mock_api.assert_called_once()
+            result_data = json.loads(result)
+            assert result_data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_electoral_districts_only_passes_preflight(self):
+        """A targeting spec using only geo_locations.electoral_districts should also pass
+        the preflight location check."""
+        mock_response = {
+            "data": [
+                {
+                    "estimate_mau": 8000,
+                    "estimate_dau": [],
+                    "bid_estimates": {},
+                    "unsupported_targeting": []
+                }
+            ]
+        }
+
+        targeting_spec = {
+            "age_min": 18,
+            "age_max": 65,
+            "geo_locations": {
+                "electoral_districts": [{"key": "US:CA14"}]
+            }
+        }
+
+        with patch('meta_ads_mcp.core.targeting.make_api_request', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_response
+
+            result = await estimate_audience_size(
+                access_token="test_token",
+                account_id="act_123456789",
+                targeting=targeting_spec
+            )
+
+            mock_api.assert_called_once()
+            result_data = json.loads(result)
+            assert result_data["success"] is True
+
+    @pytest.mark.asyncio
     async def test_error_no_parameters(self):
         """Test error when no parameters provided"""
         # Since we're using the @meta_api_tool decorator, we need to simulate


### PR DESCRIPTION
## Summary

- `estimate_audience_size`'s preflight validator (`_has_location_or_custom_audience` in `meta_ads_mcp/core/targeting.py`) only recognized `countries`/`regions`/`cities`/`zips`/`geo_markets`/`country_groups` as valid `geo_locations` keys.
- A targeting spec using **only** radius-based `geo_locations.custom_locations` was rejected with `{"error": "Missing target audience location"}` before the request ever reached Meta's `reachestimate` endpoint — even though `create_adset`/`update_adset` already accept and persist `custom_locations` correctly. Radius-targeted ad sets could not be sized via this tool at all.
- Per Meta's Marketing API docs (Location Targeting Fields reference), `custom_locations`, `places`, and `electoral_districts` are all valid `geo_locations` keys that were missing from the recognized list. Added all three (only `custom_locations` was reported, but the other two hit the exact same bug and are documented, non-obscure keys).
- Updated the two "Missing target audience location" error messages (our own preflight, and the one that reformats Meta's own `error_subcode 1885364` response) to mention the full accepted key list.

## Why not just add a workaround?

The reporting user tried adding `"countries": ["US"]` alongside `custom_locations` to get past our validator — that clears our check but Meta's real `reachestimate` API then rejects the combined spec with `error_subcode 1487756` ("Some locations conflict with each other"), which is correct Meta behavior (you can't mix a country-level location with a `custom_locations` radius in one `geo_locations` spec). The only correct fix is accepting `custom_locations` on its own.

## Test plan

- [x] Added 4 new unit tests to `tests/test_estimate_audience_size.py`:
  - `test_missing_location_rejected_by_preflight` — a spec with truly no location is still rejected before calling the Graph API (regression guard for the preflight check itself, which had no test before).
  - `test_custom_locations_only_passes_preflight` — reproduces the exact reported targeting spec and asserts it now reaches `reachestimate`.
  - `test_places_only_passes_preflight`
  - `test_electoral_districts_only_passes_preflight`
- [x] Full existing suite still green: `uv run python -m pytest tests/ -q --ignore=tests/test_estimate_audience_size_e2e.py -k "not e2e"` → 519 passed, 8 skipped.
- [x] **E2E verified live** against a local pipeboard.co dev server + local Python meta-ads-mcp instance via the `pipeboard` CLI, using the customer's exact targeting spec:
  - **Before fix** (temporarily reverted via `git stash`): `pipeboard mcp --server meta-ads-mcp tools-call --tool estimate_audience_size --args '{"account_id":"act_...","targeting":{"geo_locations":{"custom_locations":[...]}, ...}}'` → `{"error": "Missing target audience location", ...}` (never reached Meta).
  - **After fix**: the same call now reaches Meta's real `reachestimate` endpoint (visible in the constructed Graph API URL: `.../act_.../reachestimate?targeting_spec=...custom_locations...`). It fails only on an unrelated local-dev-environment `appsecret_proof` mismatch — the same error a plain `{"countries":["US"]}` spec also produces in this local environment, confirming it's not caused by this change.

## Context

Fix requested via feedback ticket from task `n_1094d202-72c1-4e48-9547-f2ac4ed09c9b`). That report also flagged a separate, unrelated issue (an implausible Meta `reachestimate` audience size for ZIP 10036/Times Square) which is upstream Meta data behavior, not something fixable in this codebase — no change included for it here.