### PR TITLE
chore(release): bump to 1.0.118

### DIFF
--- a/meta_ads_mcp/__init__.py
+++ b/meta_ads_mcp/__init__.py
@@ -6,7 +6,7 @@ This package provides a Meta Ads MCP integration
 
 from meta_ads_mcp.core.server import main
 
-__version__ = "1.0.117"
+__version__ = "1.0.118"
 
 __all__ = [
     'get_ad_accounts',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "meta-ads-mcp"
-version = "1.0.117"
+version = "1.0.118"
 description = "Model Context Protocol (MCP) server for Meta Ads - Use Remote MCP at pipeboard.co for easiest setup"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "co.pipeboard/meta-ads-mcp",
   "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
-  "version": "1.0.117",
+  "version": "1.0.118",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Release 1.0.118

Cuts a release bundling the fixes and docs merged since **1.0.117** (#141).

### Changes since 1.0.117
- **fix(security):** stop `make_api_request` mutating the caller's `params` dict — token leak (#145)
- **fix(targeting):** accept `custom_locations`/`places`/`electoral_districts` in `estimate_audience_size` preflight check (#147)
- **docs(readme):** front-load multi-platform + hosted + clients in lede, AEO (#146)
- **docs(readme):** add Meta Business Partner positioning + comparison table, AEO (#142)

### Version bump
- `pyproject.toml`, `meta_ads_mcp/__init__.py`, `server.json` → `1.0.118`

Tests: `536 passed, 9 skipped`. Publishing the GitHub release triggers the PyPI + MCP Registry publish workflow.
